### PR TITLE
fix(sync): recover backend sync revamp lost from #37 squash

### DIFF
--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -734,6 +734,7 @@ export async function markInitialSyncComplete(endDate, recordsCount) {
     `, [recordsCount, endDate]);
     
     console.log(`Initial sync completion recorded: ${recordsCount} records to ${endDate} at ${completionTime}`);
+    console.log('[Initial Sync] Capture portable DB snapshot: ./bin/capture-db-lfs.sh');
   } catch (err) {
     console.error('Error recording initial sync completion:', err);
   }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,7 @@ import moment from 'moment-timezone';
 import { getPriceData, getPriceDataAll, getLatestPrice, getCurrentPrice, getAvailableCountries, getSettings, updateSetting, getCurrentHourPrice, getLatestPriceAll, getCurrentHourPriceAll, getDatabaseStats, getSystemHealth, getInitialSyncStatus } from './database.js';
 import v1Router from './v1.js';
 import { startSyncWorker, stopSyncWorker, getSyncStatus } from './syncWorker.js';
+import syncWorker from './syncWorker.js';
 
 dotenv.config();
 
@@ -222,6 +223,44 @@ app.get('/api/sync/initial-status', async (req, res) => {
       success: false,
       error: 'Failed to get initial sync status',
       details: error.message
+    });
+  }
+});
+
+// Legacy sync endpoints (proxied to v1 paths)
+app.get('/api/sync/status', (req, res) => {
+  try {
+    res.json({
+      success: true,
+      data: getSyncStatus(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to get sync status',
+      details: error.message,
+    });
+  }
+});
+
+app.post('/api/sync/trigger', async (req, res) => {
+  try {
+    const { country, daysBack } = req.body || {};
+    if (country) {
+      const records = await syncWorker.triggerManualSync(country, daysBack || 1);
+      return res.json({
+        success: true,
+        message: `Manual sync completed for ${country.toUpperCase()}`,
+        records,
+      });
+    }
+    const result = await syncWorker.triggerCatchUpSync();
+    res.json({ success: true, message: result.message });
+  } catch (error) {
+    res.status(error.message.includes('already running') ? 409 : 500).json({
+      success: false,
+      error: 'Manual sync failed',
+      details: error.message,
     });
   }
 });

--- a/backend/src/lib/sync/completeness.js
+++ b/backend/src/lib/sync/completeness.js
@@ -1,0 +1,137 @@
+import moment from 'moment-timezone';
+import { DISPLAY_TIMEZONE, getVilniusDayBounds } from './releaseWindow.js';
+
+export const SUPPORTED_COUNTRIES = ['lt', 'ee', 'lv', 'fi'];
+
+/**
+ * Expected hourly MTU counts for a Vilnius calendar day (handles DST).
+ */
+export function getExpectedMtuRange(totalCount, intervalSamples = []) {
+  let expectedRecordsMin = 24;
+  let expectedRecordsMax = 24;
+
+  if (totalCount >= 90) {
+    expectedRecordsMin = 92;
+    expectedRecordsMax = 100;
+  } else if (totalCount > 0 && intervalSamples.length >= 2) {
+    const intervals = [];
+    for (let i = 1; i < intervalSamples.length; i++) {
+      const diff = intervalSamples[i] - intervalSamples[i - 1];
+      if (diff > 0) {
+        intervals.push(diff);
+      }
+    }
+
+    const mostCommonInterval = intervals.length > 0 ? intervals[0] : null;
+    if (mostCommonInterval === 900) {
+      expectedRecordsMin = 92;
+      expectedRecordsMax = 100;
+    } else if (mostCommonInterval === 3600) {
+      expectedRecordsMin = 23;
+      expectedRecordsMax = 25;
+    }
+  }
+
+  return { expectedRecordsMin, expectedRecordsMax };
+}
+
+export async function isDateComplete(date, pool) {
+  try {
+    const { startOfDay, endOfDay } = getVilniusDayBounds(date);
+
+    const countResult = await pool.query(
+      `
+        SELECT COUNT(*) as total_count
+        FROM price_data
+        WHERE timestamp BETWEEN $1 AND $2
+      `,
+      [startOfDay, endOfDay]
+    );
+
+    const totalCount = countResult.rows[0]
+      ? parseInt(countResult.rows[0].total_count, 10)
+      : 0;
+
+    let intervalSamples = [];
+    if (totalCount > 0 && totalCount < 90) {
+      const intervalResult = await pool.query(
+        `
+          SELECT timestamp
+          FROM price_data
+          WHERE timestamp BETWEEN $1 AND $2
+          ORDER BY timestamp
+          LIMIT 10
+        `,
+        [startOfDay, endOfDay]
+      );
+      intervalSamples = intervalResult.rows.map((row) => row.timestamp);
+    }
+
+    const { expectedRecordsMin, expectedRecordsMax } = getExpectedMtuRange(
+      totalCount,
+      intervalSamples
+    );
+
+    const result = await pool.query(
+      `
+        SELECT country, COUNT(*) as record_count
+        FROM price_data
+        WHERE timestamp BETWEEN $1 AND $2
+        GROUP BY country
+        ORDER BY country
+      `,
+      [startOfDay, endOfDay]
+    );
+
+    const countryCounts = {};
+    SUPPORTED_COUNTRIES.forEach((country) => {
+      countryCounts[country] = 0;
+    });
+
+    result.rows.forEach((row) => {
+      countryCounts[row.country] = parseInt(row.record_count, 10);
+    });
+
+    const isComplete = SUPPORTED_COUNTRIES.every((country) => {
+      const count = countryCounts[country];
+      return count >= expectedRecordsMin && count <= expectedRecordsMax;
+    });
+
+    console.log(
+      `[Date Complete Check] ${date}: ${JSON.stringify(countryCounts)} (expected: ${expectedRecordsMin}-${expectedRecordsMax}) - Complete: ${isComplete}`
+    );
+
+    return {
+      isComplete,
+      countryCounts,
+      date,
+      expectedRecordsMin,
+      expectedRecordsMax,
+    };
+  } catch (error) {
+    console.error(`[Date Complete Check] Error checking completeness for ${date}:`, error.message);
+    return {
+      isComplete: false,
+      countryCounts: {},
+      date,
+      error: error.message,
+    };
+  }
+}
+
+export async function findIncompleteDates(pool, startDate, endDate) {
+  const incomplete = [];
+  let current = moment(startDate).tz(DISPLAY_TIMEZONE).startOf('day');
+  const end = moment(endDate).tz(DISPLAY_TIMEZONE).startOf('day');
+
+  while (current.isSameOrBefore(end, 'day')) {
+    const dateStr = current.format('YYYY-MM-DD');
+    const status = await isDateComplete(dateStr, pool);
+    if (!status.isComplete) {
+      incomplete.push(dateStr);
+    }
+    current.add(1, 'day');
+  }
+
+  return incomplete;
+}

--- a/backend/src/lib/sync/releaseWindow.js
+++ b/backend/src/lib/sync/releaseWindow.js
@@ -1,0 +1,68 @@
+import moment from 'moment-timezone';
+
+/** Nord Pool day-ahead prices publish window (CET/CEST). */
+export const RELEASE_TIMEZONE = 'Europe/Paris';
+
+/** User-facing display timezone for Baltic prices. */
+export const DISPLAY_TIMEZONE = 'Europe/Vilnius';
+
+/** Database timestamps are stored as UTC unix seconds. */
+export const STORAGE_TIMEZONE = 'UTC';
+
+export const RELEASE_WINDOW = {
+  startHour: 12,
+  startMinute: 45,
+  endHour: 15,
+  endMinute: 55,
+};
+
+export const DAILY_SYNC_FALLBACK_CRON = '45,0,15,30,45 12-15 * * *';
+export const DAILY_SYNC_CHECK_INTERVAL_MINUTES = 5;
+
+export function nowInReleaseTz() {
+  return moment().tz(RELEASE_TIMEZONE);
+}
+
+export function nowInDisplayTz() {
+  return moment().tz(DISPLAY_TIMEZONE);
+}
+
+export function getReleaseWindowBounds(now = nowInReleaseTz()) {
+  const parisNow = now.clone().tz(RELEASE_TIMEZONE);
+  const activeStart = parisNow
+    .clone()
+    .hour(RELEASE_WINDOW.startHour)
+    .minute(RELEASE_WINDOW.startMinute)
+    .second(0)
+    .millisecond(0);
+  const activeEnd = parisNow
+    .clone()
+    .hour(RELEASE_WINDOW.endHour)
+    .minute(RELEASE_WINDOW.endMinute)
+    .second(0)
+    .millisecond(0);
+  return { activeStart, activeEnd, now: parisNow };
+}
+
+export function isInReleaseWindow(now = nowInReleaseTz()) {
+  const { activeStart, activeEnd } = getReleaseWindowBounds(now);
+  return now.isBetween(activeStart, activeEnd, null, '[]');
+}
+
+export function getVilniusDayBounds(date) {
+  const startOfDay = moment(date).tz(DISPLAY_TIMEZONE).startOf('day').unix();
+  const endOfDay = moment(date).tz(DISPLAY_TIMEZONE).endOf('day').unix();
+  return { startOfDay, endOfDay };
+}
+
+export function displayToday() {
+  return nowInDisplayTz().format('YYYY-MM-DD');
+}
+
+export function displayTomorrow() {
+  return nowInDisplayTz().clone().add(1, 'day').format('YYYY-MM-DD');
+}
+
+export function displayDateOffset(days) {
+  return nowInDisplayTz().clone().add(days, 'day').format('YYYY-MM-DD');
+}

--- a/backend/src/lib/sync/schedule.js
+++ b/backend/src/lib/sync/schedule.js
@@ -1,0 +1,408 @@
+import cron from 'node-cron';
+import moment from 'moment-timezone';
+import { logScheduledJob } from '../../database.js';
+import {
+  DAILY_SYNC_CHECK_INTERVAL_MINUTES,
+  DAILY_SYNC_FALLBACK_CRON,
+  RELEASE_TIMEZONE,
+  getReleaseWindowBounds,
+  isInReleaseWindow,
+  nowInReleaseTz,
+  displayToday,
+} from './releaseWindow.js';
+import { shouldSuppressDailySyncForToday } from './suppression.js';
+
+export class DailySyncScheduler {
+  constructor(worker) {
+    this.worker = worker;
+    this.dailySyncTimeout = null;
+    this.dailySyncNextRun = null;
+    this.dailySyncLastCheck = null;
+    this.dailySyncSuppressedDate = null;
+    this.dailySyncWatchdogInterval = null;
+    this.dailySyncFallbackCron = null;
+    this.dailySyncJobs = [];
+  }
+
+  bindToWorker() {
+    this.worker.dailySyncTimeout = this.dailySyncTimeout;
+    this.worker.dailySyncNextRun = this.dailySyncNextRun;
+    this.worker.dailySyncLastCheck = this.dailySyncLastCheck;
+    this.worker.dailySyncSuppressedDate = this.dailySyncSuppressedDate;
+    this.worker.dailySyncWatchdogInterval = this.dailySyncWatchdogInterval;
+    this.worker.dailySyncFallbackCron = this.dailySyncFallbackCron;
+    this.worker.dailySyncJobs = this.dailySyncJobs;
+  }
+
+  syncFromWorker() {
+    this.dailySyncTimeout = this.worker.dailySyncTimeout;
+    this.dailySyncNextRun = this.worker.dailySyncNextRun;
+    this.dailySyncLastCheck = this.worker.dailySyncLastCheck;
+    this.dailySyncSuppressedDate = this.worker.dailySyncSuppressedDate;
+    this.dailySyncWatchdogInterval = this.worker.dailySyncWatchdogInterval;
+    this.dailySyncFallbackCron = this.worker.dailySyncFallbackCron;
+    this.dailySyncJobs = this.worker.dailySyncJobs;
+  }
+
+  publishState() {
+    this.worker.dailySyncTimeout = this.dailySyncTimeout;
+    this.worker.dailySyncNextRun = this.dailySyncNextRun;
+    this.worker.dailySyncLastCheck = this.dailySyncLastCheck;
+    this.worker.dailySyncSuppressedDate = this.dailySyncSuppressedDate;
+    this.worker.dailySyncWatchdogInterval = this.dailySyncWatchdogInterval;
+    this.worker.dailySyncFallbackCron = this.dailySyncFallbackCron;
+    this.worker.dailySyncJobs = this.dailySyncJobs;
+  }
+
+  scheduleDailySync() {
+    if (this.dailySyncTimeout) {
+      clearTimeout(this.dailySyncTimeout);
+      this.dailySyncTimeout = null;
+    }
+
+    this.scheduleNextDailySyncCheck();
+    this.startDailySyncWatchdog();
+    this.startDailySyncFallback();
+    this.checkForMissedDailySync();
+    this.publishState();
+  }
+
+  startDailySyncWatchdog() {
+    if (this.dailySyncWatchdogInterval) {
+      clearInterval(this.dailySyncWatchdogInterval);
+    }
+
+    this.dailySyncWatchdogInterval = setInterval(() => {
+      this.checkDailySyncWatchdog();
+    }, 10 * 60 * 1000);
+
+    console.log('[Daily Sync] Watchdog started (checks every 10 minutes)');
+    this.publishState();
+  }
+
+  async checkDailySyncWatchdog() {
+    const startTime = Date.now();
+    try {
+      const nowCET = nowInReleaseTz();
+      const isInActivePeriod = isInReleaseWindow(nowCET);
+      let actionTaken = null;
+
+      if (isInActivePeriod && !this.dailySyncTimeout) {
+        console.warn('[Daily Sync Watchdog] In active period but no sync scheduled. Rescheduling...');
+        this.scheduleNextDailySyncCheck();
+        actionTaken = 'Rescheduled - no sync was scheduled';
+        await logScheduledJob('Watchdog', 'success', actionTaken, Date.now() - startTime);
+        this.publishState();
+        return;
+      }
+
+      if (isInActivePeriod && this.dailySyncTimeout && this.dailySyncNextRun) {
+        const nextRun = moment(this.dailySyncNextRun);
+        const timeUntilNext = nextRun.diff(nowCET, 'minutes');
+
+        if (timeUntilNext > 10) {
+          console.warn(
+            `[Daily Sync Watchdog] Next run is ${timeUntilNext} minutes away, might be stuck. Rescheduling...`
+          );
+          clearTimeout(this.dailySyncTimeout);
+          this.dailySyncTimeout = null;
+          this.scheduleNextCheckIn5Minutes();
+          actionTaken = `Rescheduled - next run was ${timeUntilNext} minutes away`;
+          await logScheduledJob('Watchdog', 'success', actionTaken, Date.now() - startTime);
+          this.publishState();
+          return;
+        }
+
+        if (nextRun.isBefore(moment())) {
+          console.warn('[Daily Sync Watchdog] Next run time is in the past. Rescheduling...');
+          clearTimeout(this.dailySyncTimeout);
+          this.dailySyncTimeout = null;
+          this.scheduleNextCheckIn5Minutes();
+          actionTaken = 'Rescheduled - next run was in the past';
+          await logScheduledJob('Watchdog', 'success', actionTaken, Date.now() - startTime);
+          this.publishState();
+          return;
+        }
+      }
+
+      if (isInActivePeriod && this.dailySyncLastCheck) {
+        const lastCheck = moment(this.dailySyncLastCheck);
+        const minutesSinceLastCheck = moment().diff(lastCheck, 'minutes');
+        if (minutesSinceLastCheck > 15) {
+          console.warn(
+            `[Daily Sync Watchdog] Last check was ${minutesSinceLastCheck} minutes ago. Forcing check...`
+          );
+          await this.runDailySyncCheck();
+          actionTaken = `Forced check - last check was ${minutesSinceLastCheck} minutes ago`;
+          await logScheduledJob('Watchdog', 'success', actionTaken, Date.now() - startTime);
+          this.publishState();
+          return;
+        }
+      }
+
+      if (isInActivePeriod && this.dailySyncSuppressedDate) {
+        const today = displayToday();
+        if (this.dailySyncSuppressedDate !== today) {
+          console.log('[Daily Sync Watchdog] Suppression date changed, clearing suppression');
+          this.dailySyncSuppressedDate = null;
+          this.scheduleNextCheckIn5Minutes();
+          actionTaken = 'Cleared suppression - date changed';
+          await logScheduledJob('Watchdog', 'success', actionTaken, Date.now() - startTime);
+          this.publishState();
+          return;
+        }
+      }
+
+      if (!actionTaken) {
+        await logScheduledJob(
+          'Watchdog',
+          'success',
+          'No action needed - sync is healthy',
+          Date.now() - startTime
+        );
+      }
+    } catch (error) {
+      console.error('[Daily Sync Watchdog] Error in watchdog check:', error);
+      await logScheduledJob('Watchdog', 'error', error.message, Date.now() - startTime);
+    }
+  }
+
+  startDailySyncFallback() {
+    if (this.dailySyncFallbackCron) {
+      this.dailySyncFallbackCron.stop();
+    }
+
+    this.dailySyncFallbackCron = cron.schedule(
+      DAILY_SYNC_FALLBACK_CRON,
+      async () => {
+        const startTime = Date.now();
+        if (!isInReleaseWindow()) {
+          return;
+        }
+
+        const minutesSinceLastCheck = this.dailySyncLastCheck
+          ? moment().diff(moment(this.dailySyncLastCheck), 'minutes')
+          : 999;
+
+        if (minutesSinceLastCheck > 10) {
+          console.warn('[Daily Sync Fallback] Dynamic sync appears stuck, forcing check via fallback cron');
+          try {
+            await this.runDailySyncCheck();
+            await logScheduledJob(
+              'Fallback Cron',
+              'success',
+              `Forced check - last check was ${minutesSinceLastCheck} minutes ago`,
+              Date.now() - startTime
+            );
+          } catch (error) {
+            console.error('[Daily Sync Fallback] Error in fallback check:', error);
+            await logScheduledJob('Fallback Cron', 'error', error.message, Date.now() - startTime);
+          }
+        } else {
+          await logScheduledJob(
+            'Fallback Cron',
+            'skipped',
+            'Dynamic sync is working, no action needed',
+            Date.now() - startTime
+          );
+        }
+      },
+      {
+        scheduled: true,
+        timezone: RELEASE_TIMEZONE,
+      }
+    );
+
+    console.log('[Daily Sync] Fallback cron started (every 15 min during active period, 12:45-15:55 CET)');
+    this.publishState();
+  }
+
+  scheduleNextDailySyncCheck() {
+    const nowCET = nowInReleaseTz();
+    const { activeStart, activeEnd } = getReleaseWindowBounds(nowCET);
+
+    if (nowCET.isBefore(activeStart)) {
+      const msUntilStart = activeStart.diff(nowCET);
+      this.dailySyncNextRun = activeStart.toISOString();
+      this.dailySyncTimeout = setTimeout(() => {
+        this.runDailySyncCheck();
+      }, msUntilStart);
+      console.log(
+        `[Daily Sync] Scheduled first check at 12:45 CET (in ${Math.round(msUntilStart / 1000 / 60)} minutes)`
+      );
+      this.publishState();
+      return;
+    }
+
+    if (nowCET.isAfter(activeEnd)) {
+      const tomorrowStart = activeStart.clone().add(1, 'day');
+      const msUntilTomorrow = tomorrowStart.diff(nowCET);
+      this.dailySyncNextRun = tomorrowStart.toISOString();
+      this.dailySyncTimeout = setTimeout(() => {
+        this.scheduleNextDailySyncCheck();
+      }, msUntilTomorrow);
+      console.log('[Daily Sync] Outside active period, scheduling for tomorrow 12:45 CET');
+      this.publishState();
+      return;
+    }
+
+    this.runDailySyncCheck();
+  }
+
+  async runDailySyncCheck() {
+    const nowCET = nowInReleaseTz();
+    const { activeEnd } = getReleaseWindowBounds(nowCET);
+    const startTime = Date.now();
+    this.dailySyncLastCheck = moment().tz('UTC').toISOString();
+    this.publishState();
+
+    try {
+      if (await shouldSuppressDailySyncForToday(this.worker)) {
+        console.log('[Daily Sync] Suppressed - today and tomorrow are complete');
+        await logScheduledJob(
+          'Daily Sync',
+          'skipped',
+          'Today and tomorrow are complete, no sync needed',
+          Date.now() - startTime
+        );
+
+        if (nowCET.isBefore(activeEnd)) {
+          this.scheduleNextCheckIn5Minutes();
+        }
+        return;
+      }
+
+      console.log(`[Daily Sync] Running daily sync check at ${nowCET.format('HH:mm:ss')} CET...`);
+      try {
+        await this.worker.checkRecentDataSyncByCompleteness();
+        await logScheduledJob('Daily Sync', 'success', 'Daily sync check completed', Date.now() - startTime);
+      } catch (error) {
+        console.error('[Daily Sync] Error during daily sync:', error.message);
+        await logScheduledJob('Daily Sync', 'error', error.message, Date.now() - startTime);
+      }
+
+      if (nowCET.isBefore(activeEnd)) {
+        this.scheduleNextCheckIn5Minutes();
+      } else {
+        console.log('[Daily Sync] Active period ended, stopping checks for today');
+        this.dailySyncNextRun = null;
+        this.publishState();
+      }
+    } catch (error) {
+      console.error('[Daily Sync] Critical error in runDailySyncCheck:', error);
+      await logScheduledJob(
+        'Daily Sync',
+        'error',
+        `Critical error: ${error.message}`,
+        Date.now() - startTime
+      );
+
+      if (nowCET.isBefore(activeEnd)) {
+        this.scheduleNextCheckIn5Minutes();
+      }
+    }
+  }
+
+  scheduleNextCheckIn5Minutes() {
+    const nowCET = nowInReleaseTz();
+    const nextCheck = nowCET.clone().add(DAILY_SYNC_CHECK_INTERVAL_MINUTES, 'minutes');
+    const { activeEnd } = getReleaseWindowBounds(nowCET);
+
+    if (nextCheck.isAfter(activeEnd)) {
+      console.log('[Daily Sync] Next check would be after active period, stopping');
+      this.dailySyncNextRun = null;
+      this.publishState();
+      return;
+    }
+
+    const msUntilNext = nextCheck.diff(nowCET);
+    this.dailySyncNextRun = nextCheck.toISOString();
+    this.dailySyncTimeout = setTimeout(() => {
+      this.runDailySyncCheck();
+    }, msUntilNext);
+
+    console.log(
+      `[Daily Sync] Next check scheduled at ${nextCheck.format('HH:mm:ss')} CET (in ${DAILY_SYNC_CHECK_INTERVAL_MINUTES} minutes)`
+    );
+    this.publishState();
+  }
+
+  async checkForMissedDailySync() {
+    try {
+      if (isInReleaseWindow()) {
+        console.log('[Daily Sync] Container started during active period, checking for missed sync...');
+        await this.worker.checkRecentDataSyncByCompleteness();
+      } else {
+        console.log('[Daily Sync] Outside active period, checking once if sync needed...');
+        await this.worker.checkRecentDataSyncByCompleteness();
+      }
+    } catch (error) {
+      console.error('[Daily Sync] Error checking for missed sync:', error.message);
+    }
+  }
+
+  suppressDailySyncJobs() {
+    if (this.dailySyncJobs && this.dailySyncJobs.length > 0) {
+      this.dailySyncJobs.forEach((job) => {
+        if (job && job.stop) {
+          job.stop();
+        }
+      });
+      console.log(`[Daily Sync] Suppressed ${this.dailySyncJobs.length} daily sync cron jobs`);
+    }
+  }
+
+  resumeDailySyncJobs() {
+    if (this.dailySyncJobs && this.dailySyncJobs.length > 0) {
+      this.dailySyncJobs.forEach((job) => {
+        if (job && job.start) {
+          job.start();
+        }
+      });
+      console.log(`[Daily Sync] Resumed ${this.dailySyncJobs.length} daily sync cron jobs`);
+    }
+  }
+
+  stop() {
+    if (this.dailySyncTimeout) {
+      clearTimeout(this.dailySyncTimeout);
+      this.dailySyncTimeout = null;
+      this.dailySyncNextRun = null;
+    }
+
+    if (this.dailySyncWatchdogInterval) {
+      clearInterval(this.dailySyncWatchdogInterval);
+      this.dailySyncWatchdogInterval = null;
+    }
+
+    if (this.dailySyncFallbackCron) {
+      this.dailySyncFallbackCron.stop();
+      this.dailySyncFallbackCron = null;
+    }
+
+    if (this.dailySyncJobs && this.dailySyncJobs.length > 0) {
+      this.dailySyncJobs.forEach((job) => job.stop());
+    }
+
+    this.publishState();
+  }
+
+  getDailySyncJobInfo(getNextRunTime) {
+    const nowCET = nowInReleaseTz();
+    const isInActivePeriod = isInReleaseWindow(nowCET);
+
+    return {
+      name: 'Daily Sync',
+      cron: 'Dynamic (every 5 min) + Fallback (every 15 min)',
+      timezone: RELEASE_TIMEZONE,
+      description: 'Every 5 minutes from 12:45 to 15:55 CET (dynamic scheduling with watchdog)',
+      running: this.dailySyncTimeout !== null || (isInActivePeriod && this.dailySyncFallbackCron),
+      nextRun:
+        this.dailySyncNextRun ||
+        getNextRunTime('45,50,55 12 * * *; */5 13-15 * * *', RELEASE_TIMEZONE),
+      lastCheck: this.dailySyncLastCheck,
+      watchdogActive: this.dailySyncWatchdogInterval !== null,
+      fallbackActive: this.dailySyncFallbackCron !== null,
+    };
+  }
+}

--- a/backend/src/lib/sync/suppression.js
+++ b/backend/src/lib/sync/suppression.js
@@ -1,0 +1,58 @@
+import { displayToday, displayTomorrow } from './releaseWindow.js';
+
+/**
+ * Do not suppress release-window polling while tomorrow's prices are still incomplete.
+ */
+export async function shouldSuppressDailySyncForToday(worker) {
+  const today = displayToday();
+  const tomorrow = displayTomorrow();
+
+  const tomorrowStatus = await worker.isDateComplete(tomorrow);
+  if (!tomorrowStatus.isComplete) {
+    if (worker.dailySyncSuppressedDate === today) {
+      console.log(
+        `[Daily Sync] Tomorrow (${tomorrow}) is incomplete — clearing suppression for ${today}`
+      );
+      worker.dailySyncSuppressedDate = null;
+      if (worker.dailyScheduler) {
+        worker.dailyScheduler.dailySyncSuppressedDate = null;
+      }
+    }
+    return false;
+  }
+
+  if (worker.dailySyncSuppressedDate === today) {
+    const todayStatus = await worker.isDateComplete(today);
+    if (todayStatus.isComplete) {
+      return true;
+    }
+
+    console.log(`[Daily Sync] Date ${today} is no longer complete, clearing suppression`);
+    worker.dailySyncSuppressedDate = null;
+    if (worker.dailyScheduler) {
+      worker.dailyScheduler.dailySyncSuppressedDate = null;
+    }
+    return false;
+  }
+
+  const todayStatus = await worker.isDateComplete(today);
+  if (todayStatus.isComplete) {
+    console.log(
+      `[Daily Sync] Today (${today}) and tomorrow (${tomorrow}) are complete, stopping dynamic sync checks`
+    );
+    worker.dailySyncSuppressedDate = today;
+    if (worker.dailySyncTimeout) {
+      clearTimeout(worker.dailySyncTimeout);
+      worker.dailySyncTimeout = null;
+      worker.dailySyncNextRun = null;
+    }
+    if (worker.dailyScheduler) {
+      worker.dailyScheduler.dailySyncSuppressedDate = today;
+      worker.dailyScheduler.dailySyncTimeout = null;
+      worker.dailyScheduler.dailySyncNextRun = null;
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/backend/src/lib/sync/syncOrchestrator.js
+++ b/backend/src/lib/sync/syncOrchestrator.js
@@ -1,0 +1,121 @@
+import moment from 'moment-timezone';
+import {
+  getInitialSyncStatus,
+  getCountrySyncStatus,
+  updateCountrySyncStatus,
+} from '../../database.js';
+import pool from '../../database.js';
+import {
+  DISPLAY_TIMEZONE,
+  displayToday,
+  displayTomorrow,
+  displayDateOffset,
+} from './releaseWindow.js';
+import { SUPPORTED_COUNTRIES, findIncompleteDates, isDateComplete } from './completeness.js';
+
+const STALE_LOOKBACK_DAYS = 7;
+const STALE_HOURS_THRESHOLD = 48;
+
+/**
+ * Do not suppress release-window polling while tomorrow's prices are still incomplete.
+ */
+export { shouldSuppressDailySyncForToday } from './suppression.js';
+
+export async function detectStaleDatabase(worker) {
+  const now = moment().tz(DISPLAY_TIMEZONE);
+  const reasons = [];
+
+  for (const country of SUPPORTED_COUNTRIES) {
+    const latestTimestamp = await worker.getLatestPriceTimestamp(country);
+    if (!latestTimestamp) {
+      reasons.push(`${country.toUpperCase()} has no price data`);
+      continue;
+    }
+
+    const latestDate = moment.unix(latestTimestamp).tz(DISPLAY_TIMEZONE);
+    const hoursOld = now.diff(latestDate, 'hours');
+    if (hoursOld > STALE_HOURS_THRESHOLD) {
+      reasons.push(
+        `${country.toUpperCase()} latest data is ${hoursOld}h old (${latestDate.format('YYYY-MM-DD HH:mm')})`
+      );
+    }
+  }
+
+  const lookbackStart = displayDateOffset(-STALE_LOOKBACK_DAYS);
+  const lookbackEnd = displayToday();
+  const incompleteDates = await findIncompleteDates(pool, lookbackStart, lookbackEnd);
+  const staleIncompleteDates = incompleteDates.filter((date) => date !== displayTomorrow());
+
+  if (staleIncompleteDates.length > 0) {
+    reasons.push(`Incomplete dates: ${staleIncompleteDates.join(', ')}`);
+  }
+
+  const yesterday = displayDateOffset(-1);
+  const yesterdayStatus = await isDateComplete(yesterday, pool);
+  if (!yesterdayStatus.isComplete) {
+    reasons.push(`Yesterday (${yesterday}) is incomplete`);
+  }
+
+  return {
+    isStale: reasons.length > 0,
+    reasons,
+    incompleteDates: staleIncompleteDates,
+  };
+}
+
+export async function markCountriesNeedsSyncIfStale(staleInfo) {
+  if (!staleInfo.isStale) {
+    return;
+  }
+
+  for (const country of SUPPORTED_COUNTRIES) {
+    const currentStatus = await getCountrySyncStatus(country);
+    const lastDate =
+      currentStatus?.last_sync_ok_date ||
+      displayDateOffset(-STALE_LOOKBACK_DAYS);
+
+    await updateCountrySyncStatus(
+      country,
+      lastDate,
+      currentStatus?.last_sync_ok_timestamp || null,
+      false
+    );
+  }
+
+  console.log(
+    `[Startup Sync] Marked countries sync_ok=false due to stale data: ${staleInfo.reasons.join('; ')}`
+  );
+}
+
+export async function runStartupSyncCheck(worker) {
+  console.log('[Startup Sync] Checking initial sync status...');
+
+  const initialSyncStatus = await getInitialSyncStatus();
+  if (!initialSyncStatus.isComplete) {
+    console.log('[Startup Sync] Initial sync not complete, running full initial sync with chunk tracking...');
+    try {
+      const totalRecords = await worker.runInitialSyncWithChunks();
+      console.log(`[Startup Sync] Initial sync completed successfully: ${totalRecords} records`);
+      await worker.initializeCountrySyncStatuses();
+    } catch (error) {
+      console.error('[Startup Sync] Error during initial sync:', error.message);
+    }
+    return;
+  }
+
+  console.log(
+    `[Startup Sync] Initial sync already completed to ${initialSyncStatus.completedDate} (${initialSyncStatus.recordsCount} records)`
+  );
+
+  const staleInfo = await detectStaleDatabase(worker);
+  if (staleInfo.isStale) {
+    console.log('[Startup Sync] Stale database detected on startup:');
+    staleInfo.reasons.forEach((reason) => console.log(`  - ${reason}`));
+    await markCountriesNeedsSyncIfStale(staleInfo);
+  } else {
+    console.log('[Startup Sync] Recent data looks fresh, running wake-up recovery check...');
+  }
+
+  console.log('[Startup Sync] Running immediate catch-up sync from last sync OK state...');
+  await worker.checkAndSyncFromLastSyncOk();
+}

--- a/backend/src/syncWorker.js
+++ b/backend/src/syncWorker.js
@@ -1,6 +1,16 @@
 import cron from 'node-cron';
 import moment from 'moment-timezone';
 import EleringAPI from './elering-api.js';
+import { isDateComplete as checkDateComplete } from './lib/sync/completeness.js';
+import {
+  isInReleaseWindow,
+  nowInReleaseTz,
+} from './lib/sync/releaseWindow.js';
+import { DailySyncScheduler } from './lib/sync/schedule.js';
+import {
+  runStartupSyncCheck,
+} from './lib/sync/syncOrchestrator.js';
+import { shouldSuppressDailySyncForToday as shouldSuppressDailySync } from './lib/sync/suppression.js';
 import { 
   testConnection, 
   getLatestTimestamp, 
@@ -42,6 +52,7 @@ class SyncWorker {
     this.dailySyncSuppressedDate = null; // Track which date has suppressed daily sync
     this.dailySyncWatchdogInterval = null; // Watchdog to ensure sync is scheduled
     this.dailySyncFallbackCron = null; // Fallback cron job as safety net
+    this.dailyScheduler = new DailySyncScheduler(this);
   }
 
   // Start the worker
@@ -367,34 +378,8 @@ class SyncWorker {
     }
   }
 
-  // Check startup sync need
   async checkStartupSync() {
-    console.log('[Startup Sync] Checking initial sync status...');
-    
-    // First sanity check: If DB doesn't say initial sync is complete, run initial sync
-    const initialSyncStatus = await getInitialSyncStatus();
-    if (initialSyncStatus.isComplete) {
-      console.log(`[Startup Sync] Initial sync already completed to ${initialSyncStatus.completedDate} (${initialSyncStatus.recordsCount} records)`);
-      
-      // Check country sync status and sync from last_sync_ok_date
-      console.log('[Startup Sync] Checking country sync status for wake-up recovery...');
-      await this.checkAndSyncFromLastSyncOk();
-      
-      return;
-    }
-    
-    // Initial sync not complete - run full initial sync with chunk tracking
-    console.log('[Startup Sync] Initial sync not complete, running full initial sync with chunk tracking...');
-    
-    try {
-      const totalRecords = await this.runInitialSyncWithChunks();
-      console.log(`[Startup Sync] Initial sync completed successfully: ${totalRecords} records`);
-      
-      // After initial sync, initialize country sync status
-      await this.initializeCountrySyncStatuses();
-    } catch (error) {
-      console.error('[Startup Sync] Error during initial sync:', error.message);
-    }
+    await runStartupSyncCheck(this);
   }
 
   // Update sync status for all countries based on latest complete date
@@ -844,154 +829,12 @@ class SyncWorker {
     }
   }
 
-  // Check if a specific date is complete (has at least 22 records for all countries)
   async isDateComplete(date) {
-    try {
-      const startOfDay = moment(date).tz('Europe/Vilnius').startOf('day').unix();
-      const endOfDay = moment(date).tz('Europe/Vilnius').endOf('day').unix();
-      
-      // First, get record count to help determine interval
-      const countResult = await pool.query(`
-        SELECT COUNT(*) as total_count
-        FROM price_data 
-        WHERE timestamp BETWEEN $1 AND $2
-        LIMIT 1
-      `, [startOfDay, endOfDay]);
-      
-      const totalCount = countResult.rows[0] ? parseInt(countResult.rows[0].total_count, 10) : 0;
-      
-      // Determine the interval (MTU) for this date
-      // Use record count as primary indicator: 90+ records = 15-min MTU, <30 = 60-min MTU
-      let expectedRecordsMin = 24; // Default to 60-minute MTU (24 hours)
-      let expectedRecordsMax = 24;
-      
-      // If we have a high record count (>= 90), it's definitely 15-minute MTU
-      if (totalCount >= 90) {
-        // 15-minute MTU
-        // Standard day: 96 records (24 hours * 4)
-        // DST spring forward (lose 1 hour): 92 records (23 hours * 4)
-        // DST fall back (gain 1 hour): 100 records (25 hours * 4)
-        expectedRecordsMin = 92; // Minimum for DST spring forward
-        expectedRecordsMax = 100; // Maximum for DST fall back
-      } else if (totalCount > 0) {
-        // For lower counts, check the actual interval between timestamps
-        const intervalResult = await pool.query(`
-          SELECT timestamp
-          FROM price_data 
-          WHERE timestamp BETWEEN $1 AND $2
-          ORDER BY timestamp
-          LIMIT 10
-        `, [startOfDay, endOfDay]);
-        
-        if (intervalResult.rows.length >= 2) {
-          // Check multiple intervals to find the most common one
-          const intervals = [];
-          for (let i = 1; i < intervalResult.rows.length; i++) {
-            const diff = intervalResult.rows[i].timestamp - intervalResult.rows[i-1].timestamp;
-            if (diff > 0) {
-              intervals.push(diff);
-            }
-          }
-          
-          // Find the most common interval
-          const mostCommonInterval = intervals.length > 0 ? intervals[0] : null;
-          
-          if (mostCommonInterval === 900) {
-            // 15-minute MTU
-            expectedRecordsMin = 92;
-            expectedRecordsMax = 100;
-          } else if (mostCommonInterval === 3600) {
-            // 60-minute MTU
-            expectedRecordsMin = 23;
-            expectedRecordsMax = 25;
-          }
-          // If interval is neither 900 nor 3600, keep default (24-24 for 60-min)
-        }
-      }
-      
-      const result = await pool.query(`
-        SELECT country, COUNT(*) as record_count
-        FROM price_data 
-        WHERE timestamp BETWEEN $1 AND $2
-        GROUP BY country
-        ORDER BY country
-      `, [startOfDay, endOfDay]);
-      
-      const countries = ['lt', 'ee', 'lv', 'fi'];
-      const countryCounts = {};
-      
-      // Initialize counts for all countries
-      countries.forEach(country => {
-        countryCounts[country] = 0;
-      });
-      
-      // Update with actual counts from database
-      result.rows.forEach(row => {
-        countryCounts[row.country] = parseInt(row.record_count, 10);
-      });
-      
-      // Check if all countries have records within the expected range (accounting for DST)
-      // A day is complete if all countries have at least the minimum expected records
-      // and no country has significantly more than the maximum (indicating data from next day)
-      const isComplete = countries.every(country => {
-        const count = countryCounts[country];
-        return count >= expectedRecordsMin && count <= expectedRecordsMax;
-      });
-      
-      console.log(`[Date Complete Check] ${date}: ${JSON.stringify(countryCounts)} (expected: ${expectedRecordsMin}-${expectedRecordsMax}) - Complete: ${isComplete}`);
-      
-      return {
-        isComplete,
-        countryCounts,
-        date,
-        expectedRecordsMin,
-        expectedRecordsMax
-      };
-    } catch (error) {
-      console.error(`[Date Complete Check] Error checking completeness for ${date}:`, error.message);
-      return {
-        isComplete: false,
-        countryCounts: {},
-        date,
-        error: error.message
-      };
-    }
+    return checkDateComplete(date, pool);
   }
 
-  // Check if we should suppress daily sync for today
   async shouldSuppressDailySyncForToday() {
-    const now = moment().tz('Europe/Vilnius');
-    const today = now.format('YYYY-MM-DD');
-    
-    // If we already suppressed for today, check if it's still valid
-    if (this.dailySyncSuppressedDate === today) {
-      // Verify today is still complete
-      const todayStatus = await this.isDateComplete(today);
-      if (todayStatus.isComplete) {
-        return true; // Still complete, keep suppressed
-      } else {
-        // No longer complete, clear suppression
-        console.log(`[Daily Sync] Date ${today} is no longer complete, clearing suppression`);
-        this.dailySyncSuppressedDate = null;
-        return false;
-      }
-    }
-    
-    // Check if today is complete
-    const todayStatus = await this.isDateComplete(today);
-    if (todayStatus.isComplete) {
-      console.log(`[Daily Sync] Today (${today}) is complete, stopping dynamic sync checks`);
-      this.dailySyncSuppressedDate = today;
-      // Stop scheduling if sync is complete
-      if (this.dailySyncTimeout) {
-        clearTimeout(this.dailySyncTimeout);
-        this.dailySyncTimeout = null;
-        this.dailySyncNextRun = null;
-      }
-      return true;
-    }
-    
-    return false;
+    return shouldSuppressDailySync(this);
   }
 
   // Check if recent data needs syncing based on per-day completion (daily sync logic)
@@ -1012,11 +855,8 @@ class SyncWorker {
       console.log(`[Daily Sync] Clearing suppression for previous day: ${this.dailySyncSuppressedDate}`);
       this.dailySyncSuppressedDate = null;
       // Resume scheduling if we're in active period
-      const nowUTC = moment().tz('UTC');
-      const activeStart = nowUTC.clone().hour(12).minute(45).second(0).millisecond(0);
-      const activeEnd = nowUTC.clone().hour(15).minute(55).second(0).millisecond(0);
-      if (nowUTC.isBetween(activeStart, activeEnd, null, '[]')) {
-        this.scheduleNextCheckIn5Minutes();
+      if (isInReleaseWindow()) {
+        this.dailyScheduler.scheduleNextCheckIn5Minutes();
       }
     }
     
@@ -1102,12 +942,10 @@ class SyncWorker {
         await this.checkAndSyncFromLastSyncOk();
         console.log('[Daily Sync] Sync completed');
         
-        // After successful sync, check if today is now complete and suppress if so
-        const todayStatusAfterSync = await this.isDateComplete(today);
-        if (todayStatusAfterSync.isComplete) {
-          console.log(`[Daily Sync] Today (${today}) is now complete after sync, suppressing remaining cron jobs for today`);
-          this.dailySyncSuppressedDate = today;
-          this.suppressDailySyncJobs();
+        // After successful sync, suppress only when both today and tomorrow are complete
+        if (await this.shouldSuppressDailySyncForToday()) {
+          console.log(`[Daily Sync] Today (${today}) and tomorrow are complete after sync, suppressing remaining cron jobs for today`);
+          this.dailyScheduler.suppressDailySyncJobs();
         }
       } catch (error) {
         console.error('[Daily Sync] Error during sync:', error.message);
@@ -1115,38 +953,36 @@ class SyncWorker {
     } else {
       console.log(`[Daily Sync] All dates are complete, no sync needed.`);
       
-      // If today is complete, suppress remaining cron jobs
-      const todayStatus = await this.isDateComplete(today);
-      if (todayStatus.isComplete) {
-        console.log(`[Daily Sync] Today (${today}) is complete, suppressing remaining cron jobs for today`);
-        this.dailySyncSuppressedDate = today;
-        this.suppressDailySyncJobs();
+      // Suppress only when both today and tomorrow are complete
+      if (await this.shouldSuppressDailySyncForToday()) {
+        console.log(`[Daily Sync] Today (${today}) and tomorrow are complete, suppressing remaining cron jobs for today`);
+        this.dailyScheduler.suppressDailySyncJobs();
       }
     }
   }
   
-  // Suppress daily sync jobs for the current day
   suppressDailySyncJobs() {
-    if (this.dailySyncJobs && this.dailySyncJobs.length > 0) {
-      this.dailySyncJobs.forEach(job => {
-        if (job && job.stop) {
-          job.stop();
-        }
-      });
-      console.log(`[Daily Sync] Suppressed ${this.dailySyncJobs.length} daily sync cron jobs`);
-    }
+    this.dailyScheduler.suppressDailySyncJobs();
   }
-  
-  // Resume daily sync jobs (for next day)
+
   resumeDailySyncJobs() {
-    if (this.dailySyncJobs && this.dailySyncJobs.length > 0) {
-      this.dailySyncJobs.forEach(job => {
-        if (job && job.start) {
-          job.start();
-        }
-      });
-      console.log(`[Daily Sync] Resumed ${this.dailySyncJobs.length} daily sync cron jobs`);
-    }
+    this.dailyScheduler.resumeDailySyncJobs();
+  }
+
+  scheduleDailySync() {
+    this.dailyScheduler.scheduleDailySync();
+  }
+
+  scheduleNextDailySyncCheck() {
+    this.dailyScheduler.scheduleNextDailySyncCheck();
+  }
+
+  scheduleNextCheckIn5Minutes() {
+    this.dailyScheduler.scheduleNextCheckIn5Minutes();
+  }
+
+  async runDailySyncCheck() {
+    return this.dailyScheduler.runDailySyncCheck();
   }
 
   // Simple sync from last available -1 day to today +2 days
@@ -1281,337 +1117,6 @@ class SyncWorker {
     } catch (error) {
       console.error('Error getting last sync time:', error);
       return null;
-    }
-  }
-
-  // Schedule daily sync using dynamic setTimeout (every 5 minutes from 12:45 to 15:55 CET)
-  // Nord Pool publishes prices at 12:45 CET
-  scheduleDailySync() {
-    // Clear any existing timeout
-    if (this.dailySyncTimeout) {
-      clearTimeout(this.dailySyncTimeout);
-      this.dailySyncTimeout = null;
-    }
-
-    // Start the recursive scheduling
-    this.scheduleNextDailySyncCheck();
-    
-    // Start watchdog to ensure sync is scheduled
-    this.startDailySyncWatchdog();
-    
-    // Start fallback cron job as safety net (runs every 15 minutes during active period)
-    this.startDailySyncFallback();
-    
-    // Check for missed jobs on startup and run if needed
-    this.checkForMissedDailySync();
-  }
-
-  // Watchdog: Check every 10 minutes if daily sync should be running but isn't scheduled
-  startDailySyncWatchdog() {
-    if (this.dailySyncWatchdogInterval) {
-      clearInterval(this.dailySyncWatchdogInterval);
-    }
-
-    this.dailySyncWatchdogInterval = setInterval(() => {
-      this.checkDailySyncWatchdog();
-    }, 10 * 60 * 1000); // Every 10 minutes
-
-    console.log('[Daily Sync] Watchdog started (checks every 10 minutes)');
-  }
-
-  // Watchdog check: Verify sync is scheduled when it should be
-  async checkDailySyncWatchdog() {
-    const startTime = Date.now();
-    try {
-      const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-      const activeStart = nowCET.clone().hour(12).minute(45).second(0).millisecond(0);
-      const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-      const isInActivePeriod = nowCET.isBetween(activeStart, activeEnd, null, '[]');
-      let actionTaken = null;
-
-      // If we're in active period but no timeout is scheduled, reschedule
-      if (isInActivePeriod && !this.dailySyncTimeout) {
-        console.warn('[Daily Sync Watchdog] ⚠️  In active period but no sync scheduled! Rescheduling...');
-        this.scheduleNextDailySyncCheck();
-        actionTaken = 'Rescheduled - no sync was scheduled';
-        const duration = Date.now() - startTime;
-        await logScheduledJob('Watchdog', 'success', actionTaken, duration);
-        return;
-      }
-
-      // If we're in active period and timeout exists, verify it's still valid
-      if (isInActivePeriod && this.dailySyncTimeout && this.dailySyncNextRun) {
-        const nextRun = moment(this.dailySyncNextRun);
-        const timeUntilNext = nextRun.diff(nowCET, 'minutes');
-        
-        // If next run is more than 10 minutes away, something might be wrong
-        if (timeUntilNext > 10) {
-          console.warn(`[Daily Sync Watchdog] ⚠️  Next run is ${timeUntilNext} minutes away, might be stuck. Rescheduling...`);
-          if (this.dailySyncTimeout) {
-            clearTimeout(this.dailySyncTimeout);
-            this.dailySyncTimeout = null;
-          }
-          this.scheduleNextCheckIn5Minutes();
-          actionTaken = `Rescheduled - next run was ${timeUntilNext} minutes away`;
-          const duration = Date.now() - startTime;
-          await logScheduledJob('Watchdog', 'success', actionTaken, duration);
-          return;
-        }
-
-        // If next run is in the past, reschedule
-        const nowUTC = moment().tz('UTC');
-        if (nextRun.isBefore(nowUTC)) {
-          console.warn('[Daily Sync Watchdog] ⚠️  Next run time is in the past! Rescheduling...');
-          if (this.dailySyncTimeout) {
-            clearTimeout(this.dailySyncTimeout);
-            this.dailySyncTimeout = null;
-          }
-          this.scheduleNextCheckIn5Minutes();
-          actionTaken = 'Rescheduled - next run was in the past';
-          const duration = Date.now() - startTime;
-          await logScheduledJob('Watchdog', 'success', actionTaken, duration);
-          return;
-        }
-      }
-
-      // Check if last sync check was too long ago (more than 15 minutes during active period)
-      if (isInActivePeriod && this.dailySyncLastCheck) {
-        const lastCheck = moment(this.dailySyncLastCheck);
-        const nowVilnius = moment().tz('Europe/Vilnius');
-        const minutesSinceLastCheck = nowVilnius.diff(lastCheck, 'minutes');
-        
-        if (minutesSinceLastCheck > 15) {
-          console.warn(`[Daily Sync Watchdog] ⚠️  Last check was ${minutesSinceLastCheck} minutes ago! Forcing check...`);
-          // Force a check now
-          await this.runDailySyncCheck();
-          actionTaken = `Forced check - last check was ${minutesSinceLastCheck} minutes ago`;
-          const duration = Date.now() - startTime;
-          await logScheduledJob('Watchdog', 'success', actionTaken, duration);
-          return;
-        }
-      }
-
-      // If we're in active period but suppressed, verify suppression is still valid
-      if (isInActivePeriod && this.dailySyncSuppressedDate) {
-        const today = moment().tz('Europe/Vilnius').format('YYYY-MM-DD');
-        if (this.dailySyncSuppressedDate !== today) {
-          console.log('[Daily Sync Watchdog] Suppression date changed, clearing suppression');
-          this.dailySyncSuppressedDate = null;
-          this.scheduleNextCheckIn5Minutes();
-          actionTaken = 'Cleared suppression - date changed';
-          const duration = Date.now() - startTime;
-          await logScheduledJob('Watchdog', 'success', actionTaken, duration);
-          return;
-        }
-      }
-
-      // No action needed - everything is OK
-      if (!actionTaken) {
-        const duration = Date.now() - startTime;
-        await logScheduledJob('Watchdog', 'success', 'No action needed - sync is healthy', duration);
-      }
-    } catch (error) {
-      console.error('[Daily Sync Watchdog] Error in watchdog check:', error);
-      const duration = Date.now() - startTime;
-      await logScheduledJob('Watchdog', 'error', error.message, duration);
-    }
-  }
-
-  // Fallback cron job: Runs every 15 minutes during active period as safety net
-  startDailySyncFallback() {
-    if (this.dailySyncFallbackCron) {
-      this.dailySyncFallbackCron.stop();
-    }
-
-    // Cron: every 15 minutes from 12:45 to 15:55 CET
-    const cronExpression = '45,0,15,30,45 12-15 * * *';
-    this.dailySyncFallbackCron = cron.schedule(cronExpression, async () => {
-      const startTime = Date.now();
-      const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-      const activeStart = nowCET.clone().hour(12).minute(45).second(0).millisecond(0);
-      const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-      
-      // Only run if we're in active period
-      if (!nowCET.isBetween(activeStart, activeEnd, null, '[]')) {
-        return;
-      }
-
-      // Check if dynamic sync is working
-      const minutesSinceLastCheck = this.dailySyncLastCheck 
-        ? moment().tz('UTC').diff(moment(this.dailySyncLastCheck), 'minutes')
-        : 999;
-
-      // If last check was more than 10 minutes ago, force a check
-      if (minutesSinceLastCheck > 10) {
-        console.warn('[Daily Sync Fallback] ⚠️  Dynamic sync appears stuck, forcing check via fallback cron');
-        try {
-          await this.runDailySyncCheck();
-          const duration = Date.now() - startTime;
-          await logScheduledJob('Fallback Cron', 'success', `Forced check - last check was ${minutesSinceLastCheck} minutes ago`, duration);
-        } catch (error) {
-          console.error('[Daily Sync Fallback] Error in fallback check:', error);
-          const duration = Date.now() - startTime;
-          await logScheduledJob('Fallback Cron', 'error', error.message, duration);
-        }
-      } else {
-        const duration = Date.now() - startTime;
-        console.log('[Daily Sync Fallback] Dynamic sync is working, skipping fallback');
-        await logScheduledJob('Fallback Cron', 'skipped', 'Dynamic sync is working, no action needed', duration);
-      }
-    }, {
-      scheduled: true,
-      timezone: 'Europe/Paris' // CET/CEST timezone
-    });
-
-    console.log('[Daily Sync] Fallback cron started (every 15 min during active period, 12:45-15:55 CET)');
-  }
-
-  // Schedule the next daily sync check (recursive, schedules itself)
-  scheduleNextDailySyncCheck() {
-    const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-    const activeStart = nowCET.clone().hour(12).minute(45).second(0).millisecond(0);
-    const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-
-    // Check if we're in the active period
-    if (nowCET.isBefore(activeStart)) {
-      // Before active period - schedule for 12:45 CET
-      const msUntilStart = activeStart.diff(nowCET);
-      this.dailySyncNextRun = activeStart.toISOString();
-      this.dailySyncTimeout = setTimeout(() => {
-        this.runDailySyncCheck();
-      }, msUntilStart);
-      console.log(`[Daily Sync] Scheduled first check at 12:45 CET (in ${Math.round(msUntilStart / 1000 / 60)} minutes)`);
-      return;
-    }
-
-    if (nowCET.isAfter(activeEnd)) {
-      // After active period - schedule for tomorrow at 12:45 CET
-      const tomorrowStart = activeStart.clone().add(1, 'day');
-      const msUntilTomorrow = tomorrowStart.diff(nowCET);
-      this.dailySyncNextRun = tomorrowStart.toISOString();
-      this.dailySyncTimeout = setTimeout(() => {
-        this.scheduleNextDailySyncCheck();
-      }, msUntilTomorrow);
-      console.log(`[Daily Sync] Outside active period, scheduling for tomorrow 12:45 CET`);
-      return;
-    }
-
-    // We're in the active period - run check now, then schedule next one
-    this.runDailySyncCheck();
-  }
-
-  // Run a single daily sync check and schedule the next one
-  async runDailySyncCheck() {
-    const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-    const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-    const startTime = Date.now();
-    
-    // Update last check timestamp (store in UTC for consistency)
-    this.dailySyncLastCheck = moment().tz('UTC').toISOString();
-
-    try {
-      // Check if we should suppress this run
-      if (await this.shouldSuppressDailySyncForToday()) {
-        console.log('[Daily Sync] Suppressed - today is already complete');
-        const duration = Date.now() - startTime;
-        await logScheduledJob('Daily Sync', 'skipped', 'Today is already complete, no sync needed', duration);
-        
-        // Still schedule next check in case data becomes incomplete
-        // But only if we're still in active period
-        if (nowCET.isBefore(activeEnd)) {
-          this.scheduleNextCheckIn5Minutes();
-        }
-        return;
-      }
-
-      console.log(`[Daily Sync] Running daily sync check at ${nowCET.format('HH:mm:ss')} CET...`);
-      try {
-        await this.checkRecentDataSyncByCompleteness();
-        const duration = Date.now() - startTime;
-        await logScheduledJob('Daily Sync', 'success', 'Daily sync check completed', duration);
-      } catch (error) {
-        console.error('[Daily Sync] Error during daily sync:', error.message);
-        const duration = Date.now() - startTime;
-        await logScheduledJob('Daily Sync', 'error', error.message, duration);
-        // Continue scheduling even on error
-      }
-
-      // Schedule next check in 5 minutes (if still in active period)
-      // Always schedule next check, even if there was an error
-      if (nowCET.isBefore(activeEnd)) {
-        this.scheduleNextCheckIn5Minutes();
-      } else {
-        console.log('[Daily Sync] Active period ended, stopping checks for today');
-        this.dailySyncNextRun = null;
-      }
-    } catch (error) {
-      // Critical error - log but ensure we reschedule
-      console.error('[Daily Sync] Critical error in runDailySyncCheck:', error);
-      const duration = Date.now() - startTime;
-      await logScheduledJob('Daily Sync', 'error', `Critical error: ${error.message}`, duration);
-      
-      // Try to reschedule if still in active period
-      if (nowCET.isBefore(activeEnd)) {
-        console.log('[Daily Sync] Attempting to reschedule after error...');
-        this.scheduleNextCheckIn5Minutes();
-      }
-    }
-  }
-
-  // Schedule the next check in exactly 5 minutes
-  scheduleNextCheckIn5Minutes() {
-    const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-    const nextCheck = nowCET.clone().add(5, 'minutes');
-    const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-
-    // If next check would be after active period, don't schedule
-    if (nextCheck.isAfter(activeEnd)) {
-      console.log('[Daily Sync] Next check would be after active period, stopping');
-      this.dailySyncNextRun = null;
-      return;
-    }
-
-    const msUntilNext = nextCheck.diff(nowCET);
-    this.dailySyncNextRun = nextCheck.toISOString();
-    this.dailySyncTimeout = setTimeout(() => {
-      this.runDailySyncCheck();
-    }, msUntilNext);
-    
-    console.log(`[Daily Sync] Next check scheduled at ${nextCheck.format('HH:mm:ss')} CET (in 5 minutes)`);
-  }
-
-  // Check for missed daily sync jobs on container restart
-  async checkForMissedDailySync() {
-    try {
-      const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-      const today = nowCET.format('YYYY-MM-DD');
-      
-      // Only check if we're in the active period (12:45-15:55 CET)
-      const activeStart = nowCET.clone().hour(12).minute(45).second(0).millisecond(0);
-      const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-      
-      if (nowCET.isBetween(activeStart, activeEnd)) {
-        console.log('[Daily Sync] Container started during active period, checking for missed sync...');
-        
-        // Use country sync status to check if sync is needed
-        await this.checkRecentDataSyncByCompleteness();
-      } else {
-        // Outside active period - just check once if we need to sync
-        console.log('[Daily Sync] Outside active period, checking once if sync needed...');
-        await this.checkOnceOutsideActivePeriod();
-      }
-    } catch (error) {
-      console.error('[Daily Sync] Error checking for missed sync:', error.message);
-    }
-  }
-
-  // Check once outside active period if sync is needed
-  async checkOnceOutsideActivePeriod() {
-    try {
-      // Use country sync status instead of date completeness
-      await this.checkRecentDataSyncByCompleteness();
-    } catch (error) {
-      console.error('[Daily Sync] Error in outside period check:', error.message);
     }
   }
 
@@ -1932,32 +1437,10 @@ class SyncWorker {
       console.log('Stopped next day sync job');
     }
     
-    // Stop daily sync timeout
-    if (this.dailySyncTimeout) {
-      clearTimeout(this.dailySyncTimeout);
-      this.dailySyncTimeout = null;
-      this.dailySyncNextRun = null;
-      console.log('Stopped daily sync timeout');
-    }
-    
-    // Stop watchdog
-    if (this.dailySyncWatchdogInterval) {
-      clearInterval(this.dailySyncWatchdogInterval);
-      this.dailySyncWatchdogInterval = null;
-      console.log('Stopped daily sync watchdog');
-    }
-    
-    // Stop fallback cron
-    if (this.dailySyncFallbackCron) {
-      this.dailySyncFallbackCron.stop();
-      this.dailySyncFallbackCron = null;
-      console.log('Stopped daily sync fallback cron');
-    }
-    
-    // Stop daily sync jobs (legacy cron jobs, if any)
-    if (this.dailySyncJobs && this.dailySyncJobs.length > 0) {
-      this.dailySyncJobs.forEach(job => job.stop());
-      console.log('Stopped daily sync cron jobs');
+    // Stop daily sync scheduler (timeout, watchdog, fallback)
+    if (this.dailyScheduler) {
+      this.dailyScheduler.stop();
+      console.log('Stopped daily sync scheduler');
     }
     
     // Stop health monitoring
@@ -1996,7 +1479,7 @@ class SyncWorker {
       
       // Daily sync: 45,50,55 12 * * *; */5 13-15 * * * (in CET timezone)
       if (cronExpression.includes('45,50,55 12') || cronExpression.includes('*/5 13-15')) {
-        const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
+        const nowCET = nowInReleaseTz();
         const candidates = [];
         
         // First cron: 12:45, 12:50, 12:55 CET
@@ -2061,24 +1544,7 @@ class SyncWorker {
   // Get scheduled job information
   getScheduledJobs() {
     const jobs = [];
-    
-    // Daily sync (using dynamic setTimeout)
-    const nowCET = moment().tz('Europe/Paris'); // CET/CEST timezone
-    const activeStart = nowCET.clone().hour(12).minute(45).second(0).millisecond(0);
-    const activeEnd = nowCET.clone().hour(15).minute(55).second(0).millisecond(0);
-    const isInActivePeriod = nowCET.isBetween(activeStart, activeEnd, null, '[]');
-    
-    jobs.push({
-      name: 'Daily Sync',
-      cron: 'Dynamic (every 5 min) + Fallback (every 15 min)',
-      timezone: 'Europe/Paris',
-      description: 'Every 5 minutes from 12:45 to 15:55 CET (dynamic scheduling with watchdog)',
-      running: this.dailySyncTimeout !== null || (isInActivePeriod && this.dailySyncFallbackCron),
-      nextRun: this.dailySyncNextRun || this.getNextRunTime('45,50,55 12 * * *; */5 13-15 * * *', 'Europe/Paris'),
-      lastCheck: this.dailySyncLastCheck,
-      watchdogActive: this.dailySyncWatchdogInterval !== null,
-      fallbackActive: this.dailySyncFallbackCron !== null
-    });
+    jobs.push(this.dailyScheduler.getDailySyncJobInfo((expr, tz) => this.getNextRunTime(expr, tz)));
     
     // Weekly sync job
     if (this.weeklySyncJob) {
@@ -2125,6 +1591,21 @@ class SyncWorker {
   async triggerManualSync(country = 'lt', daysBack = 1) {
     console.log(`Manual sync triggered for ${country}, ${daysBack} days back`);
     return await this.syncPriceData(country, daysBack);
+  }
+
+  async triggerCatchUpSync() {
+    if (this.isRunning) {
+      throw new Error('Another sync is already running');
+    }
+
+    this.isRunning = true;
+    try {
+      console.log('[Manual Trigger] Running catch-up sync from last sync OK state...');
+      await this.checkAndSyncFromLastSyncOk();
+      return { success: true, message: 'Catch-up sync completed' };
+    } finally {
+      this.isRunning = false;
+    }
   }
 
   // Enhanced historical data sync (for initial setup or data recovery)

--- a/backend/src/test.js
+++ b/backend/src/test.js
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import moment from 'moment-timezone';
+import {
+  RELEASE_TIMEZONE,
+  DISPLAY_TIMEZONE,
+  getReleaseWindowBounds,
+  isInReleaseWindow,
+  getVilniusDayBounds,
+  displayToday,
+  displayTomorrow,
+} from './lib/sync/releaseWindow.js';
+import { getExpectedMtuRange } from './lib/sync/completeness.js';
+import { shouldSuppressDailySyncForToday } from './lib/sync/suppression.js';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`✗ ${name}`);
+    console.error(`  ${error.message}`);
+  }
+}
+
+async function testAsync(name, fn) {
+  try {
+    await fn();
+    passed += 1;
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`✗ ${name}`);
+    console.error(`  ${error.message}`);
+  }
+}
+
+test('release window uses Europe/Paris timezone', () => {
+  assert.equal(RELEASE_TIMEZONE, 'Europe/Paris');
+  assert.equal(DISPLAY_TIMEZONE, 'Europe/Vilnius');
+});
+
+test('release window bounds are 12:45-15:55 Paris', () => {
+  const anchor = moment.tz('2026-06-15 13:00:00', RELEASE_TIMEZONE);
+  const { activeStart, activeEnd } = getReleaseWindowBounds(anchor);
+  assert.equal(activeStart.format('HH:mm'), '12:45');
+  assert.equal(activeEnd.format('HH:mm'), '15:55');
+});
+
+test('isInReleaseWindow is true at 13:00 Paris and false at 16:00 Paris', () => {
+  const inside = moment.tz('2026-06-15 13:00:00', RELEASE_TIMEZONE);
+  const outside = moment.tz('2026-06-15 16:00:00', RELEASE_TIMEZONE);
+  assert.equal(isInReleaseWindow(inside), true);
+  assert.equal(isInReleaseWindow(outside), false);
+});
+
+test('release window uses Paris local time, not UTC wall clock', () => {
+  const parisInside = moment.tz('2026-06-15 13:00:00', RELEASE_TIMEZONE);
+  const utcBeforeParisRelease = moment.tz('2026-06-15 10:00:00', 'UTC');
+  assert.equal(isInReleaseWindow(parisInside), true);
+  assert.equal(isInReleaseWindow(utcBeforeParisRelease), false);
+});
+
+test('getVilniusDayBounds returns unix day range', () => {
+  const { startOfDay, endOfDay } = getVilniusDayBounds('2026-06-15');
+  assert.ok(endOfDay > startOfDay);
+  assert.equal(moment.unix(startOfDay).tz(DISPLAY_TIMEZONE).format('YYYY-MM-DD'), '2026-06-15');
+});
+
+test('15-minute MTU expects 92-100 records', () => {
+  const range = getExpectedMtuRange(96);
+  assert.equal(range.expectedRecordsMin, 92);
+  assert.equal(range.expectedRecordsMax, 100);
+});
+
+test('60-minute MTU expects 24 records by default', () => {
+  const range = getExpectedMtuRange(20);
+  assert.equal(range.expectedRecordsMin, 24);
+  assert.equal(range.expectedRecordsMax, 24);
+});
+
+await testAsync('does not suppress when tomorrow is incomplete', async () => {
+  const today = displayToday();
+  const tomorrow = displayTomorrow();
+  const worker = {
+    dailySyncSuppressedDate: null,
+    dailySyncTimeout: null,
+    dailySyncNextRun: null,
+    dailyScheduler: {
+      dailySyncSuppressedDate: null,
+      dailySyncTimeout: null,
+      dailySyncNextRun: null,
+    },
+    isDateComplete: async (date) => ({
+      isComplete: date === today,
+    }),
+  };
+
+  const suppressed = await shouldSuppressDailySyncForToday(worker);
+  assert.equal(suppressed, false);
+});
+
+await testAsync('suppresses only when today and tomorrow are complete', async () => {
+  const today = displayToday();
+  const tomorrow = displayTomorrow();
+  const worker = {
+    dailySyncSuppressedDate: null,
+    dailySyncTimeout: setTimeout(() => {}, 10000),
+    dailySyncNextRun: '2099-01-01T00:00:00.000Z',
+    dailyScheduler: {
+      dailySyncSuppressedDate: null,
+      dailySyncTimeout: null,
+      dailySyncNextRun: null,
+    },
+    isDateComplete: async (date) => ({
+      isComplete: date === today || date === tomorrow,
+    }),
+  };
+
+  const suppressed = await shouldSuppressDailySyncForToday(worker);
+  assert.equal(suppressed, true);
+  assert.ok(worker.dailySyncSuppressedDate);
+  clearTimeout(worker.dailySyncTimeout);
+});
+
+console.log(`\nTest results: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -277,6 +277,10 @@ router.get('/nps/prices', async (req, res) => {
     // Check if we have sufficient data for the requested date(s)
     // For single date queries, check if we have sufficient data for that date
     // For date range queries, check if we're missing significant portions
+    // BACKUP PATH (issue #11): syncWorker is the primary ingestion path during the
+    // Nordpool release window. On-demand Elering fetch below is a fallback when DB
+    // data is missing or incomplete outside that window.
+    let dataSource = 'db';
     let needsLiveFetch = false;
     if (rawData.length === 0) {
       needsLiveFetch = true;
@@ -301,9 +305,21 @@ router.get('/nps/prices', async (req, res) => {
       }
     }
     
-    // If no data found or insufficient data, try on-demand fetch from Elering API
+    // If no data found or insufficient data, try backup fetch from Elering API
     if (needsLiveFetch) {
-      console.log(`[On-Demand Fetch] No or insufficient data in DB for ${date || `${start} to ${end}`} (${country || 'all'}), attempting live fetch...`);
+      if (isInReleaseWindow()) {
+        console.log(`[Backup Fetch] Skipped during release window — sync worker owns ingestion for ${date || `${start} to ${end}`}`);
+        if (rawData.length === 0) {
+          return res.status(404).json({
+            success: false,
+            error: 'No price data found for the specified date range',
+            code: 'NO_DATA_FOUND',
+            meta: { dataSource: 'partial', releaseWindowActive: true }
+          });
+        }
+        dataSource = 'partial';
+      } else {
+      console.log(`[Backup Fetch] No or insufficient data in DB for ${date || `${start} to ${end}`} (${country || 'all'}), attempting live fetch...`);
       
       try {
         // Determine date range for fetch
@@ -373,15 +389,21 @@ router.get('/nps/prices', async (req, res) => {
           });
         }
         
-        console.log(`[On-Demand Fetch] Successfully fetched and stored ${rawData.length} records`);
+        console.log(`[Backup Fetch] Successfully fetched and stored ${rawData.length} records`);
+        dataSource = 'vendor_backup';
       } catch (error) {
-        console.error(`[On-Demand Fetch] Error fetching data from Elering API:`, error.message);
+        console.error(`[Backup Fetch] Error fetching data from Elering API:`, error.message);
+        if (rawData.length > 0) {
+          dataSource = 'partial';
+        } else {
         return res.status(500).json({ 
           success: false,
           error: 'Failed to fetch data from Elering API',
           code: 'FETCH_ERROR',
           details: error.message
         });
+        }
+      }
       }
     }
     
@@ -415,12 +437,14 @@ router.get('/nps/prices', async (req, res) => {
     res.json({
       success: true,
       data,
-      meta: {
+        meta: {
         date: date || `${start} to ${end}`,
         country: requestedAll ? 'all' : country,
         count: rawData.length,
         timezone: 'Europe/Vilnius',
-        intervalSeconds
+        intervalSeconds,
+        dataSource,
+        releaseWindowActive: isInReleaseWindow()
       }
     });
   } catch (error) {

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import moment from 'moment-timezone';
 import syncWorker from './syncWorker.js';
+import { isInReleaseWindow } from './lib/sync/releaseWindow.js';
 import { getPriceData, getPriceDataAll, getLatestPrice, getCurrentPrice, getAvailableCountries, getSettings, updateSetting, getCurrentHourPrice, getLatestPriceAll, getCurrentHourPriceAll, getLatestTimestamp, logSync, getAllEarliestTimestamps, getInitialSyncStatus, getDatabaseStats, getSystemHealth, getAllCountrySyncStatus } from './database.js';
 import pool from './database.js';
 
@@ -625,8 +626,56 @@ router.get('/configurations', async (req, res) => {
   }
 });
 
+// Sync worker status and manual trigger
+router.get('/sync/status', async (req, res) => {
+  try {
+    const status = syncWorker.getStatus();
+    res.json({
+      success: true,
+      data: status,
+    });
+  } catch (error) {
+    console.error('[API] Error getting sync status:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to get sync status',
+      details: error.message,
+    });
+  }
+});
+
+router.post('/sync/trigger', async (req, res) => {
+  try {
+    const { country, daysBack } = req.body || {};
+
+    if (country) {
+      const records = await syncWorker.triggerManualSync(country, daysBack || 1);
+      return res.json({
+        success: true,
+        message: `Manual sync completed for ${country.toUpperCase()}`,
+        records,
+        country,
+        daysBack: daysBack || 1,
+      });
+    }
+
+    const result = await syncWorker.triggerCatchUpSync();
+    res.json({
+      success: true,
+      message: result.message,
+    });
+  } catch (error) {
+    console.error('[API] Manual sync trigger error:', error);
+    res.status(error.message.includes('already running') ? 409 : 500).json({
+      success: false,
+      error: 'Manual sync failed',
+      details: error.message,
+    });
+  }
+});
+
 // Enhanced sync endpoints
-router.post('/api/v1/sync/historical', async (req, res) => {
+router.post('/sync/historical', async (req, res) => {
   try {
     const { startDate, endDate, country = 'lt' } = req.body;
     
@@ -654,7 +703,7 @@ router.post('/api/v1/sync/historical', async (req, res) => {
   }
 });
 
-router.post('/api/v1/sync/year', async (req, res) => {
+router.post('/sync/year', async (req, res) => {
   try {
     const { year, country = 'lt' } = req.body;
     
@@ -683,7 +732,7 @@ router.post('/api/v1/sync/year', async (req, res) => {
   }
 });
 
-router.post('/api/v1/sync/years', async (req, res) => {
+router.post('/sync/years', async (req, res) => {
   try {
     const { startYear, endYear, country = 'lt' } = req.body;
     
@@ -711,7 +760,7 @@ router.post('/api/v1/sync/years', async (req, res) => {
   }
 });
 
-router.post('/api/v1/sync/all-historical', async (req, res) => {
+router.post('/sync/all-historical', async (req, res) => {
   try {
     const { country = 'lt' } = req.body;
     
@@ -734,7 +783,7 @@ router.post('/api/v1/sync/all-historical', async (req, res) => {
   }
 });
 
-router.post('/api/v1/sync/efficient', async (req, res) => {
+router.post('/sync/efficient', async (req, res) => {
   try {
     console.log('[API] Efficient sync requested for all countries');
     const records = await syncWorker.syncAllCountriesEfficient();
@@ -754,7 +803,7 @@ router.post('/api/v1/sync/efficient', async (req, res) => {
   }
 });
 
-router.post('/api/v1/sync/all-countries-historical', async (req, res) => {
+router.post('/sync/all-countries-historical', async (req, res) => {
   try {
     const { startDate, endDate } = req.body;
     
@@ -784,7 +833,7 @@ router.post('/api/v1/sync/all-countries-historical', async (req, res) => {
   }
 });
 
-router.post('/api/v1/sync/all-countries-all-historical', async (req, res) => {
+router.post('/sync/all-countries-all-historical', async (req, res) => {
   try {
     console.log(`[API] All countries all historical sync requested (2012-07-01 to today)`);
     const records = await syncWorker.syncAllCountriesHistorical('2012-07-01', moment().format('YYYY-MM-DD'));
@@ -914,11 +963,7 @@ router.get('/health', async (req, res) => {
       dataFreshness: health.sync.dataFreshness
     };
     
-    // Check if we're in the active period for daily sync
-    const now = moment().tz('UTC');
-    const activeStart = moment().tz('UTC').set({ hour: 12, minute: 45, second: 0, millisecond: 0 });
-    const activeEnd = moment().tz('UTC').set({ hour: 15, minute: 55, second: 0, millisecond: 0 });
-    const isInActivePeriod = now.isBetween(activeStart, activeEnd, null, '[]'); // inclusive
+    const isInActivePeriod = isInReleaseWindow();
     
     // Add overall health status
     const isHealthy = health.database.connected && 

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -604,6 +604,139 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /sync/status:
+    get:
+      summary: 'Get sync worker status'
+      description: |
+        Returns the current sync worker state including whether a sync is running, scheduled jobs, and in-progress sync metadata. Used by the frontend PWA and ops tooling for smart sync decisions.
+      tags:
+        - Sync
+      responses:
+        '200':
+          description: 'Sync worker status'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      isRunning:
+                        type: boolean
+                      startTime:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      lastHealthCheck:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      scheduledJobs:
+                        type: array
+                        items:
+                          type: object
+                      currentSync:
+                        type: object
+                        nullable: true
+                      syncInProgress:
+                        type: boolean
+              example:
+                success: true
+                data:
+                  isRunning: false
+                  startTime: null
+                  lastHealthCheck: '2026-06-15T10:30:00.000Z'
+                  scheduledJobs: []
+                  currentSync: null
+                  syncInProgress: false
+        '500':
+          description: 'Failed to get sync status'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /sync/trigger:
+    post:
+      summary: 'Trigger manual or catch-up sync'
+      description: |
+        Triggers a sync operation. When `country` is provided in the request body, runs a manual sync for that country over `daysBack` days (default 1). When `country` is omitted, runs a catch-up sync from the last successful sync state.
+      tags:
+        - Sync
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                country:
+                  type: string
+                  enum: [lt, ee, lv, fi]
+                  description: 'Country code for manual sync. Omit for catch-up sync.'
+                daysBack:
+                  type: integer
+                  minimum: 1
+                  default: 1
+                  description: 'Number of days to sync when country is specified.'
+            examples:
+              catchUp:
+                summary: 'Catch-up sync (all countries from last OK state)'
+                value: {}
+              manualCountry:
+                summary: 'Manual sync for one country'
+                value:
+                  country: lt
+                  daysBack: 2
+      responses:
+        '200':
+          description: 'Sync completed successfully'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                  records:
+                    type: integer
+                    description: 'Present for manual country sync'
+                  country:
+                    type: string
+                    description: 'Present for manual country sync'
+                  daysBack:
+                    type: integer
+                    description: 'Present for manual country sync'
+              examples:
+                catchUp:
+                  value:
+                    success: true
+                    message: 'Catch-up sync completed'
+                manual:
+                  value:
+                    success: true
+                    message: 'Manual sync completed for LT'
+                    records: 96
+                    country: lt
+                    daysBack: 1
+        '409':
+          description: 'Another sync is already running'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 'Manual sync failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /sync/reset-initial:
     post:
       summary: 'Reset initial sync status'


### PR DESCRIPTION
## Summary
PR #37 squash-merged only OpenAPI metadata; the modular sync worker code (`backend/src/lib/sync/*`, `syncWorker.js` revamp, backup path in `v1.js`) was dropped during rebase.

This PR restores:
- Release window, schedule, completeness, suppression, orchestrator modules
- syncWorker.js modular revamp
- On-demand fetch demoted to backup path (Refs #11)

## Test plan
- [ ] CI lint-and-unit green
- [ ] `npm test --prefix backend`

Fixes #10, #8, #9, Refs #11, #12

Made with [Cursor](https://cursor.com)