### PR TITLE
docs(agents): merge backend before frontend in stacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ When executing a revamp phase or adoption slice, agents MUST NOT stop after the 
 2. **Register gaps** — if you find debt or a blocker you cannot fix in the current slice, open a GitHub issue (`source:ai`) in this repo or [flows](https://github.com/alicemq/flows/issues).
 3. **Fix → commit → PR** — implement, verify locally, publish; use `Fixes #N` / `Refs #N`.
 4. **Merge when CI green** — squash-merge to `main` (repo default) when required checks pass, unless the user said "do not merge" or the PR needs a human review hold. Merging is not a stop point; agents continue the slice unless blocked.
-5. **Rebase stacked PRs** — immediately update dependent branches onto `main`. **Merge order:** foundation/lowest stack PR first, then dependents top-down.
+5. **Rebase stacked PRs** — immediately update dependent branches onto `main`. **Merge order:** foundation/lowest stack PR first, then dependents top-down. When a stack spans backend and frontend, merge backend PRs before frontend PRs so proxy routes and API contracts land first (see #50).
 6. **Continue** — pick the next issue or checklist row until the slice is complete or you are blocked (document blockers in issue/PR).
 
 The scope gate applies to each unit of work; the work loop governs sequencing across units.


### PR DESCRIPTION
## Summary

Add work-loop guidance from #50: when a stack spans backend and frontend, merge backend PRs first so API routes and contracts land before the SPA.

Refs #50

## Test plan

- [x] Doc-only change

Made with [Cursor](https://cursor.com)