### PR TITLE
chore: align flows pin to v0.6.2 (already current)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Agent handbook (AGENTS.md)
     url: https://github.com/alicemq/lt-electricity-full-price-nordpool/blob/main/AGENTS.md
     about: Scope gate, labels, and workflow before coding
-  - name: flows v0.6.1 templates
-    url: https://github.com/alicemq/flows/tree/v0.6.1/agent-handbook/templates
+  - name: flows v0.6.2 templates
+    url: https://github.com/alicemq/flows/tree/v0.6.2/agent-handbook/templates
     about: CI, issue templates, and revamp checklist source


### PR DESCRIPTION
## Summary

- Verified [flows v0.6.2](https://github.com/alicemq/flows/releases/tag/v0.6.2) is the latest release; `main` and tag both point to `725ce5e` (PR #11: NordPool adoption gaps G-201–G-205).
- No new flows tag required — v0.6.2 already includes work-loop merge directive (PR #10) and adoption gap closures (PR #11).
- `AGENTS.md` cornerstone pin was already at v0.6.2; this PR aligns `.github/ISSUE_TEMPLATE/config.yml` from stale v0.6.1.

## flows v0.6.2 adopter highlights

- `install.sh` layout profiles (`--layout monorepo|flat|legacy-api-backend`, `--api-dir`, `--frontend-dir`, `--worker-dir`)
- Release-window and timezone SSOT example stubs
- Git LFS fixture script (`capture-db-lfs.example.sh`)
- OpenAPI sync admin paths fragment
- NordPool checklist and gap register G-201–G-205 marked fixed

## Test plan

- [x] `gh release list --repo alicemq/flows` confirms v0.6.2 latest
- [x] `git rev-parse v0.6.2^{commit}` equals `origin/main` on flows
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)