### PR TITLE
docs(api): align OpenAPI with v1 routes and legacy shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: OpenAPI JSON sync check
         run: node bin/openapi-json-from-yaml.js --check
 
+      - name: OpenAPI route parity check
+        run: node bin/validate-openapi-routes.js
+
       - name: Warn if vendor/flows is behind origin/main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -181,23 +181,26 @@ docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f
 All API endpoints are accessed through the frontend proxy:
 
 ```javascript
-GET /api/v1/nps/prices/:date          // Single date prices
-GET /api/v1/nps/prices/:start/:end    // Date range prices
-GET /api/v1/nps/price/:country/latest // Latest price (Elering-style)
-GET /api/v1/nps/price/:country/current // Current hour price
-GET /api/v1/nps/price/ALL/latest      // Latest prices for all countries
-GET /api/v1/nps/price/ALL/current     // Current hour prices for all countries
-GET /api/v1/latest                    // Latest available prices
-GET /api/v1/countries                 // Available countries
-GET /api/v1/health                    // System health check
-GET /api/sync/status                  // Sync worker status
-POST /api/sync/trigger                // Manual sync trigger
-POST /api/sync/historical             // Historical data sync
-POST /api/sync/year                   // Year data sync
-POST /api/sync/all-historical         // All historical data sync
-GET /api/                             // Swagger UI documentation
-GET /api/openapi.yaml                 // OpenAPI specification
+GET /api/v1/nps/prices?date=YYYY-MM-DD&country=lt     // Single date (query params)
+GET /api/v1/nps/prices?start=YYYY-MM-DD&end=YYYY-MM-DD // Date range (query params)
+GET /api/v1/nps/prices/upcoming?country=lt            // Upcoming prices from current MTU
+GET /api/v1/nps/price/:country/latest                 // Latest price (Elering-style)
+GET /api/v1/nps/price/:country/current                // Current interval price
+GET /api/v1/nps/price/all/latest                      // Latest prices for all countries
+GET /api/v1/nps/price/all/current                     // Current interval prices for all countries
+GET /api/v1/latest                                    // Latest available prices (legacy)
+GET /api/v1/countries                                 // Available countries
+GET /api/v1/health                                    // System health check
+GET /api/v1/sync/status                               // Sync worker status
+POST /api/v1/sync/trigger                             // Manual sync trigger
+POST /api/v1/sync/historical                          // Historical data sync
+POST /api/v1/sync/year                                // Year data sync
+POST /api/v1/sync/all-historical                      // All historical data sync
+GET /api/                                             // Swagger UI documentation
+GET /api/openapi.yaml                                 // OpenAPI specification
 ```
+
+**Legacy paths:** Unversioned `/api/*` requests (for example `GET /api/sync/status`) still work via a deprecation shim that forwards to `/api/v1/*` and returns `Deprecation`, `Link`, and `Warning` headers. Prefer `/api/v1/*` for new code. See [documentation/legacy-api.md](documentation/legacy-api.md).
 
 **Country Codes**: `lt`, `ee`, `lv`, `fi` (case insensitive). When supported by an endpoint, omitting the `country` parameter returns data for all countries.
 

--- a/backend/src/legacyApi.js
+++ b/backend/src/legacyApi.js
@@ -3,6 +3,8 @@ import v1Router from './v1.js';
 /**
  * Proxy legacy /api/* requests to v1 handlers with deprecation headers.
  * Mount after app.use('/api/v1', v1Router) and before the 404 handler.
+ *
+ * @see documentation/legacy-api.md
  */
 export function legacyApiShim(req, res, next) {
   if (req.path === '/v1' || req.path.startsWith('/v1/')) {

--- a/bin/validate-openapi-routes.js
+++ b/bin/validate-openapi-routes.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Verify swagger-ui/openapi.yaml paths match backend/src/v1.js router definitions.
+ * Usage: node bin/validate-openapi-routes.js
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { createRequire } from 'module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const require = createRequire(pathToFileURL(path.join(repoRoot, 'backend/package.json')));
+const yaml = require('js-yaml');
+
+const v1Path = path.join(repoRoot, 'backend/src/v1.js');
+const yamlPath = path.join(repoRoot, 'swagger-ui/openapi.yaml');
+
+function expressPathToOpenApi(routePath) {
+  return routePath.replace(/:([A-Za-z_][A-Za-z0-9_]*)/g, '{$1}');
+}
+
+function extractV1Routes(source) {
+  const routes = new Map();
+  const pattern = /router\.(get|post|put|delete|patch)\(\s*['"]([^'"]+)['"]/g;
+  let match = pattern.exec(source);
+  while (match) {
+    const method = match[1].toUpperCase();
+    const openApiPath = expressPathToOpenApi(match[2]);
+    const key = `${method} ${openApiPath}`;
+    routes.set(key, { method, path: openApiPath });
+    match = pattern.exec(source);
+  }
+  return routes;
+}
+
+function extractOpenApiPaths(doc) {
+  const routes = new Map();
+  for (const [routePath, item] of Object.entries(doc.paths || {})) {
+    for (const [method, operation] of Object.entries(item)) {
+      if (!['get', 'post', 'put', 'delete', 'patch', 'head', 'options'].includes(method)) {
+        continue;
+      }
+      const key = `${method.toUpperCase()} ${routePath}`;
+      routes.set(key, { method: method.toUpperCase(), path: routePath, operation });
+    }
+  }
+  return routes;
+}
+
+const v1Source = fs.readFileSync(v1Path, 'utf8');
+const openApiDoc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+const v1Routes = extractV1Routes(v1Source);
+const specRoutes = extractOpenApiPaths(openApiDoc);
+
+const missingInSpec = [];
+for (const [key, route] of v1Routes) {
+  if (!specRoutes.has(key)) {
+    missingInSpec.push(key);
+  }
+}
+
+const extraInSpec = [];
+for (const [key] of specRoutes) {
+  if (!v1Routes.has(key)) {
+    extraInSpec.push(key);
+  }
+}
+
+let failed = false;
+
+if (missingInSpec.length > 0) {
+  failed = true;
+  console.error('OpenAPI spec is missing v1.js routes:');
+  for (const key of missingInSpec.sort()) {
+    console.error(`  - ${key}`);
+  }
+}
+
+if (extraInSpec.length > 0) {
+  failed = true;
+  console.error('OpenAPI spec documents routes not defined in v1.js:');
+  for (const key of extraInSpec.sort()) {
+    console.error(`  - ${key}`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(`OpenAPI paths match v1.js (${v1Routes.size} routes)`);

--- a/documentation/API.md
+++ b/documentation/API.md
@@ -4,11 +4,15 @@
 
 The Electricity Prices NordPool API provides access to electricity price data for Baltic countries (Lithuania, Estonia, Latvia, Finland) with comprehensive sync management capabilities.
 
+**OpenAPI source of truth:** `swagger-ui/openapi.yaml` (JSON generated in CI). Interactive docs: `/api/` via the frontend proxy.
+
+**Legacy compatibility:** Unversioned `/api/*` paths forward to `/api/v1/*` with deprecation headers. See [legacy-api.md](./legacy-api.md).
+
 ## Base URL
 
 ### Production
 ```
-http://localhost/api/v1/
+https://your-host/api/v1/
 ```
 
 ### Development
@@ -22,64 +26,47 @@ Currently, the API does not require authentication for public endpoints.
 
 ## Data Sync Management
 
+All sync endpoints are mounted at `/api/v1/sync/*`. Legacy `/api/sync/*` URLs still work via the deprecation shim.
+
 ### Sync Status
-Get the current status of the sync worker and last run times.
+Get the current status of the sync worker and scheduled jobs.
 
 ```http
-GET /api/sync/status
+GET /api/v1/sync/status
 ```
-
-**Response:**
-```json
-{
-  "status": "running",
-  "lastRun": "2024-12-19T10:30:00Z",
-  "nextRun": "2024-12-19T11:00:00Z",
-  "countries": ["lt", "ee", "lv", "fi"],
-  "scheduledJobs": [
-    {
-      "name": "daily-sync",
-      "schedule": "0 6 * * *",
-      "lastRun": "2024-12-19T06:00:00Z",
-      "nextRun": "2024-12-20T06:00:00Z"
-    }
-  ]
-}
-```
-
-### Manual Sync Trigger
-Trigger a manual sync for specified countries and days.
-
-```http
-POST /api/sync/trigger
-Content-Type: application/json
-
-{
-  "country": "lt",
-  "days": 1
-}
-```
-
-**Parameters:**
-- `country` (string, optional): Country code (`lt`, `ee`, `lv`, `fi`). If omitted, returns data for all countries (where supported).
-- `days` (number, required): Number of days to sync (1-30)
 
 **Response:**
 ```json
 {
   "success": true,
-  "message": "Sync triggered successfully",
-  "recordsProcessed": 672,
-  "processingTime": 478,
-  "countries": ["lt", "ee", "lv", "fi"]
+  "data": {
+    "isRunning": false,
+    "scheduledJobs": [],
+    "syncInProgress": false
+  }
 }
 ```
 
-### Historical Data Sync
-Sync historical data for a specific date range.
+### Manual Sync Trigger
+Trigger a manual sync for one country or a catch-up sync for all countries.
 
 ```http
-POST /api/sync/historical
+POST /api/v1/sync/trigger
+Content-Type: application/json
+
+{
+  "country": "lt",
+  "daysBack": 1
+}
+```
+
+**Parameters:**
+- `country` (string, optional): Country code (`lt`, `ee`, `lv`, `fi`). Omit for catch-up sync.
+- `daysBack` (number, optional): Days to sync when `country` is set (default: 1)
+
+### Historical Data Sync
+```http
+POST /api/v1/sync/historical
 Content-Type: application/json
 
 {
@@ -89,27 +76,9 @@ Content-Type: application/json
 }
 ```
 
-**Parameters:**
-- `country` (string, required): Country code (`lt`, `ee`, `lv`, `fi`, `all`)
-- `startDate` (string, required): Start date in YYYY-MM-DD format
-- `endDate` (string, required): End date in YYYY-MM-DD format
-
-**Response:**
-```json
-{
-  "success": true,
-  "message": "Historical sync completed",
-  "recordsProcessed": 8760,
-  "processingTime": 5240,
-  "dateRange": "2024-01-01 to 2024-12-31"
-}
-```
-
 ### Year Data Sync
-Sync all data for a specific year.
-
 ```http
-POST /api/sync/year
+POST /api/v1/sync/year
 Content-Type: application/json
 
 {
@@ -118,26 +87,9 @@ Content-Type: application/json
 }
 ```
 
-**Parameters:**
-- `country` (string, required): Country code (`lt`, `ee`, `lv`, `fi`, `all`)
-- `year` (number, required): Year to sync (2012-present)
-
-**Response:**
-```json
-{
-  "success": true,
-  "message": "Year sync completed",
-  "recordsProcessed": 8760,
-  "processingTime": 5240,
-  "year": 2024
-}
-```
-
 ### All Historical Data Sync
-Sync all available historical data for a country.
-
 ```http
-POST /api/sync/all-historical
+POST /api/v1/sync/all-historical
 Content-Type: application/json
 
 {
@@ -145,122 +97,19 @@ Content-Type: application/json
 }
 ```
 
-**Parameters:**
-- `country` (string, required): Country code (`lt`, `ee`, `lv`, `fi`, `all`)
-
-**Response:**
-```json
-{
-  "success": true,
-  "message": "All historical sync completed",
-  "recordsProcessed": 87600,
-  "processingTime": 52400,
-  "dateRange": "2012-07-01 to 2024-12-19"
-}
-```
-
 ## Price Data Endpoints
 
+Price queries use **query parameters**, not path segments. Primary data comes from the background sync worker; when the database is empty or incomplete for a requested date, `GET /nps/prices` may perform a one-time backup fetch from the Elering API before responding.
+
 ### Get Prices for Single Date
-Retrieve electricity prices for a specific date.
-Returns one record per market time unit (MTU), which MAY be either 60-minute (legacy data) or 15-minute (new MTU) depending on the source data for that day.
-
 ```http
-GET /api/v1/nps/prices/{date}
+GET /api/v1/nps/prices?date=2024-12-19&country=lt
 ```
 
 **Parameters:**
-- `date` (string, required): Date in YYYY-MM-DD format
-
-**Response:**
-```json
-{
-  "date": "2024-12-19",
-  "prices": [
-    {
-      "hour": 0,
-      "lt": 45.23,
-      "ee": 42.15,
-      "lv": 44.78,
-      "fi": 41.92
-    },
-    {
-      "hour": 1,
-      "lt": 43.87,
-      "ee": 41.23,
-      "lv": 43.45,
-      "fi": 40.78
-    }
-  ]
-}
-```
-
-### Get Prices for Date Range
-Retrieve electricity prices for a date range.
-Each date in the range returns one record per MTU (hourly or 15-minute), rather than assuming a fixed 24 records per day.
-
-```http
-GET /api/v1/nps/prices/{startDate}/{endDate}
-```
-
-**Parameters:**
-- `startDate` (string, required): Start date in YYYY-MM-DD format
-- `endDate` (string, required): End date in YYYY-MM-DD format
-
-**Response:**
-```json
-{
-  "startDate": "2024-12-19",
-  "endDate": "2024-12-20",
-  "prices": [
-    {
-      "date": "2024-12-19",
-      "prices": [
-        {
-          "hour": 0,
-          "lt": 45.23,
-          "ee": 42.15,
-          "lv": 44.78,
-          "fi": 41.92
-        }
-      ]
-    }
-  ]
-}
-```
-
-### Get Latest Price for Country
-Get the latest available price for a specific country (latest MTU up to now, independent of whether the underlying data is hourly or 15-minute).
-
-```http
-GET /api/v1/nps/price/{country}/latest
-```
-
-**Parameters:**
-- `country` (string, required): Country code (`lt`, `ee`, `lv`, `fi`)
-
-**Response:**
-```json
-{
-  "country": "lt",
-  "price": 45.23,
-  "timestamp": "2024-12-19T10:00:00Z",
-  "hour": 10
-}
-```
-
-### Get Current Interval Price
-Get the price for the **current MTU interval** (for example, the current 15‑minute slot once Nord Pool 15-minute MTU is in effect).
-
-### Get Upcoming Prices
-Retrieve upcoming electricity prices from the current MTU to the end of today and tomorrow (Europe/Vilnius timezone).
-
-```http
-GET /api/v1/nps/prices/upcoming?country={country}
-```
-
-**Parameters:**
-- `country` (string, optional): Country code (`lt`, `ee`, `lv`, `fi`), defaults to `lt`.
+- `date` (string): Date in `YYYY-MM-DD` format (use with single-day queries)
+- `start` / `end` (string): Date range (both required together)
+- `country` (string, optional): `lt`, `ee`, `lv`, or `fi`. Omit for all countries.
 
 **Response:**
 ```json
@@ -268,108 +117,66 @@ GET /api/v1/nps/prices/upcoming?country={country}
   "success": true,
   "data": {
     "lt": [
-      { "timestamp": 1750932000, "price": 75.0 },
-      { "timestamp": 1750932900, "price": 68.5 }
+      { "timestamp": 1750885200, "price": 75.0 }
     ]
   },
   "meta": {
+    "date": "2024-12-19",
     "country": "lt",
-    "count": 2,
+    "count": 24,
     "timezone": "Europe/Vilnius",
-    "intervalSeconds": 900,
-    "current_time_local": "2025-06-26 12:07:00",
-    "date_range": {
-      "start": "2025-06-26",
-      "end": "2025-06-27"
-    }
+    "intervalSeconds": 3600
   }
 }
 ```
 
+### Get Prices for Date Range
 ```http
-GET /api/v1/nps/price/{country}/current
+GET /api/v1/nps/prices?start=2024-12-01&end=2024-12-31&country=ee
+```
+
+### Get Latest Price for Country
+```http
+GET /api/v1/nps/price/lt/latest
 ```
 
 **Parameters:**
-- `country` (string, required): Country code (`lt`, `ee`, `lv`, `fi`)
+- `country` (path): `lt`, `ee`, `lv`, `fi`, or `all`
 
-**Response:**
-```json
-{
-  "country": "lt",
-  "price": 45.23,
-  "timestamp": "2024-12-19T10:00:00Z",
-  "hour": 10,
-  "isCurrent": true
-}
+### Get Current Interval Price
+```http
+GET /api/v1/nps/price/lt/current
 ```
+
+Returns the latest available market time unit (MTU) up to "now" in Europe/Vilnius.
+
+### Get Upcoming Prices
+```http
+GET /api/v1/nps/prices/upcoming?country=lt
+```
+
+Returns slots from the current MTU through end of today and tomorrow.
 
 ### Get Latest Prices for All Countries
-Get the latest prices for all countries.
-
 ```http
-GET /api/v1/nps/price/ALL/latest
+GET /api/v1/nps/price/all/latest
 ```
 
-**Response:**
-```json
-{
-  "timestamp": "2024-12-19T10:00:00Z",
-  "prices": {
-    "lt": 45.23,
-    "ee": 42.15,
-    "lv": 44.78,
-    "fi": 41.92
-  }
-}
-```
-
-### Get Current Hour Prices for All Countries
-Get the current hour prices for all countries.
-
+### Get Current Interval Prices for All Countries
 ```http
-GET /api/v1/nps/price/ALL/current
-```
-
-**Response:**
-```json
-{
-  "timestamp": "2024-12-19T10:00:00Z",
-  "prices": {
-    "lt": 45.23,
-    "ee": 42.15,
-    "lv": 44.78,
-    "fi": 41.92
-  },
-  "isCurrent": true
-}
+GET /api/v1/nps/price/all/current
 ```
 
 ## System Endpoints
 
 ### Health Check
-Check the health status of the API.
-
 ```http
 GET /api/v1/health
 ```
 
-**Response:**
-```json
-{
-  "status": "healthy",
-  "timestamp": "2024-12-19T10:30:00Z",
-  "version": "2.0.0",
-  "services": {
-    "database": "connected",
-    "sync": "running"
-  }
-}
-```
+Also available at root `GET /health` for container liveness (slimmer payload).
 
 ### Get Available Countries
-Get list of available countries.
-
 ```http
 GET /api/v1/countries
 ```
@@ -377,171 +184,46 @@ GET /api/v1/countries
 **Response:**
 ```json
 {
-  "countries": [
-    {
-      "code": "lt",
-      "name": "Lithuania"
-    },
-    {
-      "code": "ee",
-      "name": "Estonia"
-    },
-    {
-      "code": "lv",
-      "name": "Latvia"
-    },
-    {
-      "code": "fi",
-      "name": "Finland"
-    }
+  "success": true,
+  "data": [
+    { "code": "lt", "name": "Lithuania" },
+    { "code": "ee", "name": "Estonia" },
+    { "code": "lv", "name": "Latvia" },
+    { "code": "fi", "name": "Finland" }
   ]
 }
 ```
 
-### Get Latest Available Prices
-Get the latest available prices for all countries.
-
+### Get Latest Available Prices (legacy)
 ```http
-GET /api/v1/latest
+GET /api/v1/latest?country=lt
 ```
 
-**Response:**
-```json
-{
-  "timestamp": "2024-12-19T10:00:00Z",
-  "prices": {
-    "lt": 45.23,
-    "ee": 42.15,
-    "lv": 44.78,
-    "fi": 41.92
-  }
-}
-```
+Deprecated; prefer `/api/v1/nps/price/{country}/latest`.
 
 ## CLI Commands
 
-The system includes comprehensive CLI commands for sync management. These can be run inside the backend container:
-
-### Sync All Countries
-```bash
-npm run cli all <days>
-```
-
-**Example:**
-```bash
-npm run cli all 7
-```
-
-### Historical Sync
-```bash
-npm run cli historical <country> <startDate> <endDate>
-```
-
-**Example:**
-```bash
-npm run cli historical lt 2024-01-01 2024-12-31
-```
-
-### Year Sync
-```bash
-npm run cli year <year> <country>
-```
-
-**Example:**
-```bash
-npm run cli year 2024 lt
-```
-
-### All Historical Sync
-```bash
-npm run cli all-historical <country>
-```
-
-**Example:**
-```bash
-npm run cli all-historical lt
-```
-
-### Test Sync Functionality
-```bash
-npm run cli test
-```
-
-### Check Sync Status
-```bash
-npm run cli status
-```
+Sync management CLI commands run inside the backend container. See `backend/package.json` scripts and OpenAPI `/sync/*` POST endpoints for HTTP equivalents.
 
 ## Error Handling
 
-All endpoints return appropriate HTTP status codes and error messages:
-
-### Error Response Format
 ```json
 {
-  "error": "Error message",
-  "code": "ERROR_CODE",
-  "timestamp": "2024-12-19T10:30:00Z"
+  "success": false,
+  "error": "Human-readable message",
+  "code": "NO_DATA_FOUND"
 }
 ```
 
-### Common Error Codes
-- `400` - Bad Request (invalid parameters)
-- `404` - Not Found (data not available)
-- `500` - Internal Server Error (server error)
-- `503` - Service Unavailable (sync in progress)
-
-## Rate Limiting
-
-Currently, no rate limiting is implemented. Consider implementing rate limiting for production use.
-
-## CORS
-
-CORS is properly configured for cross-origin requests in production mode.
-
-## Data Format
-
-### Timestamps
-All timestamps are in ISO 8601 format with UTC timezone.
-
-### Prices
-Prices are in EUR/MWh and represent the electricity price for each hour.
-
-### Country Codes
-- `lt` - Lithuania
-- `ee` - Estonia
-- `lv` - Latvia
-- `fi` - Finland
-- `all` - All countries (for sync operations)
+Common HTTP status codes: `400`, `404`, `409` (sync already running), `500`.
 
 ## Interactive Documentation
 
-For interactive API documentation and testing, visit:
-- **Production**: http://localhost/api/
-- **Development**: http://localhost:5173/api/
+- **Production**: `https://your-host/api/`
+- **Development**: `http://localhost:5173/api/`
 
-The Swagger UI provides a complete interactive interface for testing all endpoints.
-
-## Technology Stack
-
-### Backend
-- **Node.js**: 20 (LTS)
-- **Express**: 4.18.2
-- **PostgreSQL**: 17 (Database)
-- **node-cron**: 3.0.3 (Scheduling)
-- **axios**: 1.6.0 (HTTP client)
-- **pg**: 8.11.3 (PostgreSQL client)
-
-### Frontend
-- **Vue.js**: 3.5.17
-- **Vite**: 7.0.0 (Build tool)
-- **Nginx**: stable-alpine (Production proxy)
-
-### Infrastructure
-- **Docker**: Containerized deployment
-- **Swagger UI**: Interactive API documentation
+Swagger UI loads `openapi.yaml` through the frontend proxy at `/api/v1` server URL.
 
 ---
 
-**API Version**: 2.0.0  
-**Last Updated**: December 19, 2024 
+**Contract version:** OpenAPI `info.version` in `swagger-ui/openapi.yaml`

--- a/documentation/legacy-api.md
+++ b/documentation/legacy-api.md
@@ -1,0 +1,45 @@
+# Legacy API compatibility (`/api/*`)
+
+## Overview
+
+The backend mounts versioned routes at `/api/v1/*` via `backend/src/v1.js`. A compatibility shim in `backend/src/legacyApi.js` forwards unversioned `/api/*` requests to the same handlers so older clients keep working during migration.
+
+## Canonical vs legacy paths
+
+| Legacy (deprecated) | Canonical successor |
+| --- | --- |
+| `GET /api/nps/prices?date=...` | `GET /api/v1/nps/prices?date=...` |
+| `GET /api/sync/status` | `GET /api/v1/sync/status` |
+| `POST /api/sync/trigger` | `POST /api/v1/sync/trigger` |
+| Any other `/api/<path>` | `/api/v1/<path>` |
+
+Requests that already target `/api/v1/*` are not rewritten.
+
+## Deprecation headers
+
+Legacy requests receive RFC 8594-style headers on every response:
+
+- `Deprecation: true`
+- `Link: </api/v1/...>; rel="successor-version"` (full successor URL including query string)
+- `Warning: 299 - "Legacy /api/* path; use /api/v1/*"`
+
+New integrations MUST use `/api/v1/*`. The shim exists for backward compatibility only.
+
+## Mount order
+
+In `backend/src/index.js`:
+
+1. `app.use('/api/v1', v1Router)` — primary API
+2. `app.use('/api', legacyApiShim)` — legacy forwarding (skips paths starting with `/v1`)
+
+Root `GET /health` (without `/api`) is a separate liveness endpoint on the Express app; `GET /api/v1/health` is the richer diagnostics handler in `v1.js`.
+
+## OpenAPI source of truth
+
+Interactive docs and the machine-readable contract live under `swagger-ui/`:
+
+- Source: `swagger-ui/openapi.yaml`
+- Generated: `swagger-ui/openapi.json` (run `node bin/openapi-json-from-yaml.js --write`)
+- CI checks: `bin/validate-openapi-routes.js` and `bin/openapi-json-from-yaml.js --check`
+
+Swagger UI is served at `/api/` through the frontend proxy in production.

--- a/swagger-ui/openapi.json
+++ b/swagger-ui/openapi.json
@@ -3,10 +3,10 @@
   "info": {
     "title": "Electricity Prices NordPool API",
     "version": "1.0.0",
-    "description": "# Electricity Prices NordPool API\n\nComprehensive API for accessing electricity price data from NordPool via Elering API.\n\n## Features\n- **Multi-country support**: Lithuania (LT), Estonia (EE), Latvia (LV), Finland (FI)\n- **DST-aware timestamps**: Proper handling of daylight saving time transitions\n- **Historical data**: Access to price data from 2012-07-01 to present\n- **Real-time updates**: Latest clearing prices from NordPool\n- **Secure architecture**: All requests routed through frontend proxy\n\n## Architecture\n- **Production**: All API calls go through frontend proxy at `/api/v1/*`\n- **Development**: Direct backend access available for debugging\n- **Security**: Backend services not exposed to internet\n\n## Data Sources\n- **Primary**: Elering API (https://dashboard.elering.ee/api/nps/price)\n- **Storage**: PostgreSQL database with optimized queries\n- **Sync**: Automated every 30 minutes during NordPool hours\n\n## Timezone Handling\n- **Market timezone**: Europe/Vilnius (CET/CEST)\n- **NordPool boundaries**: 22:00 UTC to 21:59 UTC\n- **DST conversion**: Automatic handling of daylight saving time\n\n## Rate Limits\n- **No current limits**: API designed for public access\n- **Caching**: Database-based caching for optimal performance\n- **Monitoring**: All requests logged for analytics\n",
+    "description": "# Electricity Prices NordPool API\n\nComprehensive API for accessing electricity price data from NordPool via Elering API.\n\n## Features\n- **Multi-country support**: Lithuania (LT), Estonia (EE), Latvia (LV), Finland (FI)\n- **DST-aware timestamps**: Proper handling of daylight saving time transitions\n- **Historical data**: Access to price data from 2012-07-01 to present\n- **Real-time updates**: Latest clearing prices from NordPool\n- **Secure architecture**: All requests routed through frontend proxy\n\n## Architecture\n- **Production**: All API calls go through frontend proxy at `/api/v1/*`\n- **Development**: Direct backend access available for debugging\n- **Security**: Backend services not exposed to internet\n\n## Data Sources\n- **Primary**: Elering API (https://dashboard.elering.ee/api/nps/price)\n- **Storage**: PostgreSQL database with optimized queries\n- **Sync**: Automated every 30 minutes during NordPool hours\n\n## Timezone Handling\n- **Market timezone**: Europe/Vilnius (CET/CEST)\n- **NordPool boundaries**: 22:00 UTC to 21:59 UTC\n- **DST conversion**: Automatic handling of daylight saving time\n\n## Rate Limits\n- **No current limits**: API designed for public access\n- **Caching**: Database-based caching for optimal performance\n- **Monitoring**: All requests logged for analytics\n\n## Legacy `/api/*` paths (deprecated)\nRequests to `/api/*` (without the `/v1` segment) are handled by a compatibility shim that\nforwards to the matching `/api/v1/*` handler. Responses include RFC 8594 deprecation headers:\n`Deprecation: true`, `Link: </api/v1/...>; rel=\"successor-version\"`, and\n`Warning: 299 - \"Legacy /api/* path; use /api/v1/*\"`. Prefer `/api/v1/*` for new integrations.\nSee `documentation/legacy-api.md` for details.\n",
     "contact": {
       "name": "Electricity Prices Team",
-      "url": "https://github.com/your-repo/electricity-prices"
+      "url": "https://github.com/alicemq/lt-electricity-full-price-nordpool"
     },
     "license": {
       "name": "AGPL-3.0-only",
@@ -14,7 +14,7 @@
     },
     "externalDocs": {
       "description": "Project Documentation",
-      "url": "https://github.com/your-repo/electricity-prices/blob/main/README.md"
+      "url": "https://github.com/alicemq/lt-electricity-full-price-nordpool/blob/main/README.md"
     }
   },
   "servers": [
@@ -787,9 +787,10 @@
     "/latest": {
       "get": {
         "summary": "Get latest price (legacy endpoint)",
-        "description": "Legacy endpoint for backward compatibility",
+        "description": "**Deprecated.** Legacy compatibility endpoint. Prefer `GET /nps/price/{country}/latest`.\n",
+        "deprecated": true,
         "tags": [
-          "Prices"
+          "Legacy"
         ],
         "parameters": [
           {
@@ -877,6 +878,166 @@
           },
           "404": {
             "description": "No price data found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prices": {
+      "get": {
+        "summary": "Get price data (legacy redirect)",
+        "description": "**Deprecated.** Redirects to `/nps/prices` with the same query parameters.\nUse `GET /nps/prices` instead.\n",
+        "deprecated": true,
+        "tags": [
+          "Legacy"
+        ],
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "lt",
+                "ee",
+                "lv",
+                "fi"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to /nps/prices with preserved query string"
+          }
+        }
+      }
+    },
+    "/settings": {
+      "get": {
+        "summary": "Get application settings",
+        "description": "Returns key-value settings stored in the database.",
+        "tags": [
+          "Configuration"
+        ],
+        "responses": {
+          "200": {
+            "description": "Settings object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to fetch settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/settings/{key}": {
+      "put": {
+        "summary": "Update a setting",
+        "tags": [
+          "Configuration"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "description": "New value for the setting"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Setting updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to update setting",
             "content": {
               "application/json": {
                 "schema": {
@@ -1081,6 +1242,272 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/sync/historical": {
+      "post": {
+        "summary": "Sync historical data for a date range",
+        "tags": [
+          "Sync"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "country": {
+                    "type": "string",
+                    "enum": [
+                      "lt",
+                      "ee",
+                      "lv",
+                      "fi"
+                    ],
+                    "default": "lt"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Historical sync completed"
+          },
+          "400": {
+            "description": "Missing required parameters"
+          },
+          "500": {
+            "description": "Historical sync failed"
+          }
+        }
+      }
+    },
+    "/sync/year": {
+      "post": {
+        "summary": "Sync all data for a specific year",
+        "tags": [
+          "Sync"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "year"
+                ],
+                "properties": {
+                  "year": {
+                    "type": "integer"
+                  },
+                  "country": {
+                    "type": "string",
+                    "enum": [
+                      "lt",
+                      "ee",
+                      "lv",
+                      "fi"
+                    ],
+                    "default": "lt"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Year sync completed"
+          },
+          "400": {
+            "description": "Missing year"
+          },
+          "500": {
+            "description": "Year sync failed"
+          }
+        }
+      }
+    },
+    "/sync/years": {
+      "post": {
+        "summary": "Sync data for a range of years",
+        "tags": [
+          "Sync"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "startYear",
+                  "endYear"
+                ],
+                "properties": {
+                  "startYear": {
+                    "type": "integer"
+                  },
+                  "endYear": {
+                    "type": "integer"
+                  },
+                  "country": {
+                    "type": "string",
+                    "enum": [
+                      "lt",
+                      "ee",
+                      "lv",
+                      "fi"
+                    ],
+                    "default": "lt"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Year range sync completed"
+          },
+          "400": {
+            "description": "Missing year range"
+          },
+          "500": {
+            "description": "Year range sync failed"
+          }
+        }
+      }
+    },
+    "/sync/all-historical": {
+      "post": {
+        "summary": "Sync all historical data for one country",
+        "description": "Syncs from 2012-07-01 through today for the given country.",
+        "tags": [
+          "Sync"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "country": {
+                    "type": "string",
+                    "enum": [
+                      "lt",
+                      "ee",
+                      "lv",
+                      "fi"
+                    ],
+                    "default": "lt"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "All historical sync completed"
+          },
+          "500": {
+            "description": "All historical sync failed"
+          }
+        }
+      }
+    },
+    "/sync/efficient": {
+      "post": {
+        "summary": "Efficient sync for all countries",
+        "description": "Runs an optimized multi-country sync using batched Elering API calls.",
+        "tags": [
+          "Sync"
+        ],
+        "responses": {
+          "200": {
+            "description": "Efficient sync completed"
+          },
+          "500": {
+            "description": "Efficient sync failed"
+          }
+        }
+      }
+    },
+    "/sync/all-countries-historical": {
+      "post": {
+        "summary": "Historical sync for all countries in parallel",
+        "tags": [
+          "Sync"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "All countries historical sync completed"
+          },
+          "400": {
+            "description": "Missing date range"
+          },
+          "500": {
+            "description": "Sync failed"
+          }
+        }
+      }
+    },
+    "/sync/all-countries-all-historical": {
+      "post": {
+        "summary": "Full historical sync for all countries",
+        "description": "Syncs 2012-07-01 through today for LT, EE, LV, and FI in parallel.",
+        "tags": [
+          "Sync"
+        ],
+        "responses": {
+          "200": {
+            "description": "Full historical sync completed"
+          },
+          "500": {
+            "description": "Sync failed"
           }
         }
       }
@@ -1453,6 +1880,93 @@
           }
         }
       }
+    },
+    "/sync/date-complete/{date}": {
+      "get": {
+        "summary": "Check data completeness for a date",
+        "tags": [
+          "Sync"
+        ],
+        "parameters": [
+          {
+            "name": "date",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Date completeness status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid date format"
+          },
+          "500": {
+            "description": "Failed to check completeness"
+          }
+        }
+      }
+    },
+    "/sync/recent-completeness": {
+      "get": {
+        "summary": "Check today and yesterday completeness",
+        "tags": [
+          "Sync"
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent completeness for today and yesterday",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "today": {
+                          "type": "object"
+                        },
+                        "yesterday": {
+                          "type": "object"
+                        },
+                        "needsSync": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to check recent completeness"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1697,6 +2211,14 @@
     {
       "name": "Configuration",
       "description": "Price configuration and tariff endpoints"
+    },
+    {
+      "name": "Sync",
+      "description": "Sync worker status and admin triggers"
+    },
+    {
+      "name": "Legacy",
+      "description": "Deprecated compatibility endpoints; prefer /nps/* equivalents"
     }
   ]
 }

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -33,16 +33,23 @@ info:
     - **No current limits**: API designed for public access
     - **Caching**: Database-based caching for optimal performance
     - **Monitoring**: All requests logged for analytics
+
+    ## Legacy `/api/*` paths (deprecated)
+    Requests to `/api/*` (without the `/v1` segment) are handled by a compatibility shim that
+    forwards to the matching `/api/v1/*` handler. Responses include RFC 8594 deprecation headers:
+    `Deprecation: true`, `Link: </api/v1/...>; rel="successor-version"`, and
+    `Warning: 299 - "Legacy /api/* path; use /api/v1/*"`. Prefer `/api/v1/*` for new integrations.
+    See `documentation/legacy-api.md` for details.
     
   contact:
     name: 'Electricity Prices Team'
-    url: 'https://github.com/your-repo/electricity-prices'
+    url: 'https://github.com/alicemq/lt-electricity-full-price-nordpool'
   license:
     name: 'AGPL-3.0-only'
     url: 'https://www.gnu.org/licenses/agpl-3.0.html'
   externalDocs:
     description: 'Project Documentation'
-    url: 'https://github.com/your-repo/electricity-prices/blob/main/README.md'
+    url: 'https://github.com/alicemq/lt-electricity-full-price-nordpool/blob/main/README.md'
 servers:
   - url: /api/v1
     description: 'Production API Server (via proxy)'
@@ -536,9 +543,11 @@ paths:
   /latest:
     get:
       summary: 'Get latest price (legacy endpoint)'
-      description: 'Legacy endpoint for backward compatibility'
+      description: |
+        **Deprecated.** Legacy compatibility endpoint. Prefer `GET /nps/price/{country}/latest`.
+      deprecated: true
       tags:
-        - Prices
+        - Legacy
       parameters:
         - name: country
           in: query
@@ -590,6 +599,103 @@ paths:
                   last_updated: '2025-06-26T00:15:30.024Z'
         '404':
           description: 'No price data found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /prices:
+    get:
+      summary: 'Get price data (legacy redirect)'
+      description: |
+        **Deprecated.** Redirects to `/nps/prices` with the same query parameters.
+        Use `GET /nps/prices` instead.
+      deprecated: true
+      tags:
+        - Legacy
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: start
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: end
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: country
+          in: query
+          schema:
+            type: string
+            enum: [lt, ee, lv, fi]
+      responses:
+        '302':
+          description: 'Redirect to /nps/prices with preserved query string'
+  /settings:
+    get:
+      summary: 'Get application settings'
+      description: 'Returns key-value settings stored in the database.'
+      tags:
+        - Configuration
+      responses:
+        '200':
+          description: 'Settings object'
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '500':
+          description: 'Failed to fetch settings'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /settings/{key}:
+    put:
+      summary: 'Update a setting'
+      tags:
+        - Configuration
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  description: 'New value for the setting'
+      responses:
+        '200':
+          description: 'Setting updated'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        '400':
+          description: 'Missing value'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: 'Failed to update setting'
           content:
             application/json:
               schema:
@@ -726,6 +832,166 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /sync/historical:
+    post:
+      summary: 'Sync historical data for a date range'
+      tags:
+        - Sync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [startDate, endDate]
+              properties:
+                startDate:
+                  type: string
+                  format: date
+                endDate:
+                  type: string
+                  format: date
+                country:
+                  type: string
+                  enum: [lt, ee, lv, fi]
+                  default: lt
+      responses:
+        '200':
+          description: 'Historical sync completed'
+        '400':
+          description: 'Missing required parameters'
+        '500':
+          description: 'Historical sync failed'
+
+  /sync/year:
+    post:
+      summary: 'Sync all data for a specific year'
+      tags:
+        - Sync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [year]
+              properties:
+                year:
+                  type: integer
+                country:
+                  type: string
+                  enum: [lt, ee, lv, fi]
+                  default: lt
+      responses:
+        '200':
+          description: 'Year sync completed'
+        '400':
+          description: 'Missing year'
+        '500':
+          description: 'Year sync failed'
+
+  /sync/years:
+    post:
+      summary: 'Sync data for a range of years'
+      tags:
+        - Sync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [startYear, endYear]
+              properties:
+                startYear:
+                  type: integer
+                endYear:
+                  type: integer
+                country:
+                  type: string
+                  enum: [lt, ee, lv, fi]
+                  default: lt
+      responses:
+        '200':
+          description: 'Year range sync completed'
+        '400':
+          description: 'Missing year range'
+        '500':
+          description: 'Year range sync failed'
+
+  /sync/all-historical:
+    post:
+      summary: 'Sync all historical data for one country'
+      description: 'Syncs from 2012-07-01 through today for the given country.'
+      tags:
+        - Sync
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                country:
+                  type: string
+                  enum: [lt, ee, lv, fi]
+                  default: lt
+      responses:
+        '200':
+          description: 'All historical sync completed'
+        '500':
+          description: 'All historical sync failed'
+
+  /sync/efficient:
+    post:
+      summary: 'Efficient sync for all countries'
+      description: 'Runs an optimized multi-country sync using batched Elering API calls.'
+      tags:
+        - Sync
+      responses:
+        '200':
+          description: 'Efficient sync completed'
+        '500':
+          description: 'Efficient sync failed'
+
+  /sync/all-countries-historical:
+    post:
+      summary: 'Historical sync for all countries in parallel'
+      tags:
+        - Sync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [startDate, endDate]
+              properties:
+                startDate:
+                  type: string
+                  format: date
+                endDate:
+                  type: string
+                  format: date
+      responses:
+        '200':
+          description: 'All countries historical sync completed'
+        '400':
+          description: 'Missing date range'
+        '500':
+          description: 'Sync failed'
+
+  /sync/all-countries-all-historical:
+    post:
+      summary: 'Full historical sync for all countries'
+      description: 'Syncs 2012-07-01 through today for LT, EE, LV, and FI in parallel.'
+      tags:
+        - Sync
+      responses:
+        '200':
+          description: 'Full historical sync completed'
+        '500':
+          description: 'Sync failed'
 
   /sync/reset-initial:
     post:
@@ -990,6 +1256,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /sync/date-complete/{date}:
+    get:
+      summary: 'Check data completeness for a date'
+      tags:
+        - Sync
+      parameters:
+        - name: date
+          in: path
+          required: true
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: 'Date completeness status'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+        '400':
+          description: 'Invalid date format'
+        '500':
+          description: 'Failed to check completeness'
+
+  /sync/recent-completeness:
+    get:
+      summary: 'Check today and yesterday completeness'
+      tags:
+        - Sync
+      responses:
+        '200':
+          description: 'Recent completeness for today and yesterday'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      today:
+                        type: object
+                      yesterday:
+                        type: object
+                      needsSync:
+                        type: boolean
+        '500':
+          description: 'Failed to check recent completeness'
+
 components:
   schemas:
     Country:
@@ -1152,4 +1474,8 @@ tags:
   - name: Countries
     description: 'Country information endpoints' 
   - name: Configuration
-    description: 'Price configuration and tariff endpoints' 
+    description: 'Price configuration and tariff endpoints'
+  - name: Sync
+    description: 'Sync worker status and admin triggers'
+  - name: Legacy
+    description: 'Deprecated compatibility endpoints; prefer /nps/* equivalents'


### PR DESCRIPTION
## Summary
- Add `bin/validate-openapi-routes.js` and wire it into CI so OpenAPI paths must match all `v1.js` router definitions
- Document missing sync admin, settings, and legacy `/prices` endpoints in `swagger-ui/openapi.yaml`; regenerate `openapi.json`
- Add `documentation/legacy-api.md` and align `documentation/API.md` + `README.md` with query-param price URLs and canonical `/api/v1/*` paths
- Cross-reference legacy shim from `backend/src/legacyApi.js`

Fixes #19

## Test plan
- [x] `node bin/validate-openapi-routes.js`
- [x] `node bin/openapi-json-from-yaml.js --check`
- [x] `npm test` (backend)
- [x] `npm run build` (frontend)
- [ ] CI lint-and-unit + Gitleaks green


Made with [Cursor](https://cursor.com)