### PR TITLE
fix(secrets): complete env untrack local workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ When you find a defect, missing test, doc drift, or scope gap during work and yo
 ## Secrets policy
 
 - **Never commit** `.env`, passwords, or API keys. Use `.env.example` and `deploy/local.env.example` with `CHANGE_ME` placeholders.
-- Tracked `.env.development` / `.env.production` remain in git history until a dedicated untrack PR (issue #3); new local files MUST use gitignored copies.
+- Live `.env`, `.env.development`, and `.env.production` are gitignored; copy from `.env.example` locally (`./scripts/dev.sh` and `./scripts/prod.sh` seed on first run).
 - Production secrets belong in Coolify env vars, not YAML in the repo.
 
 ## Local verification

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ A modern, containerized electricity price monitoring system for Baltic countries
 git clone <repository-url>
 cd LT-electricity-full-price-NordPool
 
+# First run: copy .env.example to .env.production and set POSTGRES_PASSWORD (or use ./scripts/prod.sh)
+cp .env.example .env.production
+
 # Start in production mode (secure architecture)
 ./scripts/prod.sh
 
@@ -27,6 +30,9 @@ docker-compose --env-file .env.production up -d --build
 
 #### **Development Mode**
 ```bash
+# First run: copy .env.example to .env.development (or use ./scripts/dev.sh)
+cp .env.example .env.development
+
 # Start in development mode (exposed services for debugging)
 ./scripts/dev.sh
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -3,11 +3,16 @@
 # Development startup script
 echo "🚀 Starting Electricity Prices in Development Mode..."
 
-# Copy development environment
-cp .env.development .env
+# Local env files are gitignored — seed from .env.example on first run
+ENV_FILE=".env.development"
+if [ ! -f "$ENV_FILE" ]; then
+  cp .env.example "$ENV_FILE"
+  echo "Created $ENV_FILE from .env.example — review values before use."
+fi
+cp "$ENV_FILE" .env
 
 # Build and start services with development override
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file .env.development up -d --build
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file "$ENV_FILE" up -d --build
 
 echo "✅ Development environment started!"
 echo ""

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -3,11 +3,16 @@
 # Production startup script
 echo "🚀 Starting Electricity Prices in Production Mode..."
 
-# Copy production environment
-cp .env.production .env
+# Local env files are gitignored — seed from .env.example on first run
+ENV_FILE=".env.production"
+if [ ! -f "$ENV_FILE" ]; then
+  cp .env.example "$ENV_FILE"
+  echo "Created $ENV_FILE from .env.example — set strong POSTGRES_PASSWORD before production use."
+fi
+cp "$ENV_FILE" .env
 
 # Build and start services
-docker-compose --env-file .env.production up -d --build
+docker-compose --env-file "$ENV_FILE" up -d --build
 
 echo "✅ Production environment started!"
 echo ""


### PR DESCRIPTION
## Summary

- Update `scripts/dev.sh` and `scripts/prod.sh` to seed gitignored env files from `.env.example` on first run
- Document local env setup in README quick start (copy from example, never commit live values)
- Update AGENTS.md secrets policy to reflect completed untrack (PR #25 removed tracked `.env*`; this finishes operator docs/scripts)

## Test plan

- [x] `docker compose config -q`
- [ ] CI green on PR

## Notes

- Issue #34 (Coolify POSTGRES_PASSWORD rotation) remains blocked pending operator confirmation of production credential state.

Fixes #3

Made with [Cursor](https://cursor.com)