### PR TITLE
docs(readme): clone with --recurse-submodules for vendor/flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A modern, containerized electricity price monitoring system for Baltic countries
 
 #### **Production Mode (Recommended)**
 ```bash
-# Clone the repository
-git clone <repository-url>
+# Clone the repository (includes vendor/flows read-only handbook submodule)
+git clone --recurse-submodules <repository-url>
 cd LT-electricity-full-price-NordPool
 
 # First run: copy .env.example to .env.production and set POSTGRES_PASSWORD (or use ./scripts/prod.sh)


### PR DESCRIPTION
## Summary

- Document `git clone --recurse-submodules` in README quick start so `vendor/flows` handbook is present on first checkout

## Test plan

- [x] Docs-only change
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)