### PR TITLE
feat(admin): cron schedule viewer and editor API v1 (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ FRONTEND_COMMAND=npm run dev -- --host 0.0.0.0
 BACKEND_COMMAND=npm run dev
 ELERING_API_URL=https://dashboard.elering.ee/api/nps/price
 DATABASE_URL=postgresql://electricity_user:CHANGE_ME@db:5432/electricity_prices
+ADMIN_API_TOKEN=CHANGE_ME
 
 # Database (development only — use platform secrets in production)
 POSTGRES_DB=electricity_prices

--- a/backend/src/lib/admin/auth.js
+++ b/backend/src/lib/admin/auth.js
@@ -1,0 +1,29 @@
+/**
+ * Admin API token gate. Set ADMIN_API_TOKEN in the environment.
+ */
+export function requireAdminToken(req, res, next) {
+  const configuredToken = process.env.ADMIN_API_TOKEN;
+  if (!configuredToken) {
+    return res.status(503).json({
+      success: false,
+      error: 'Admin API not configured',
+      code: 'ADMIN_NOT_CONFIGURED',
+    });
+  }
+
+  const authHeader = req.headers.authorization || '';
+  const bearerToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const headerToken = req.headers['x-admin-token'];
+  const provided = bearerToken || headerToken;
+
+  if (!provided || provided !== configuredToken) {
+    return res.status(401).json({
+      success: false,
+      error: 'Unauthorized',
+      code: 'ADMIN_UNAUTHORIZED',
+    });
+  }
+
+  req.adminActor = req.headers['x-admin-actor'] || 'admin-api';
+  next();
+}

--- a/backend/src/lib/admin/cronSchedules.js
+++ b/backend/src/lib/admin/cronSchedules.js
@@ -1,0 +1,80 @@
+import pool from '../../database.js';
+import { validateCronSchedule } from './cronValidation.js';
+
+export { validateCronSchedule };
+
+export async function listCronSchedules() {
+  const result = await pool.query(
+    `SELECT job_key, name, cron_expression, timezone, description, enabled, editable, updated_at
+     FROM cron_schedules
+     ORDER BY job_key`,
+  );
+  return result.rows;
+}
+
+export async function getCronSchedule(jobKey) {
+  const result = await pool.query(
+    `SELECT job_key, name, cron_expression, timezone, description, enabled, editable, updated_at
+     FROM cron_schedules
+     WHERE job_key = $1`,
+    [jobKey],
+  );
+  return result.rows[0] || null;
+}
+
+export async function updateCronSchedule(jobKey, { cronExpression, timezone, enabled }, changedBy) {
+  const existing = await getCronSchedule(jobKey);
+  if (!existing) {
+    return { ok: false, status: 404, error: 'Cron job not found' };
+  }
+  if (!existing.editable) {
+    return { ok: false, status: 400, error: 'Cron job is read-only' };
+  }
+
+  const nextExpression = cronExpression ?? existing.cron_expression;
+  const nextTimezone = timezone ?? existing.timezone;
+  const nextEnabled = enabled ?? existing.enabled;
+
+  const validation = validateCronSchedule(nextExpression, nextTimezone);
+  if (!validation.valid) {
+    return { ok: false, status: 400, error: validation.error };
+  }
+
+  await pool.query(
+    `UPDATE cron_schedules
+     SET cron_expression = $2,
+         timezone = $3,
+         enabled = $4,
+         updated_at = CURRENT_TIMESTAMP
+     WHERE job_key = $1`,
+    [jobKey, nextExpression, nextTimezone, nextEnabled],
+  );
+
+  await pool.query(
+    `INSERT INTO cron_schedule_audit
+       (job_key, old_cron_expression, new_cron_expression, old_timezone, new_timezone, changed_by)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [
+      jobKey,
+      existing.cron_expression,
+      nextExpression,
+      existing.timezone,
+      nextTimezone,
+      changedBy || 'admin-api',
+    ],
+  );
+
+  return { ok: true, schedule: await getCronSchedule(jobKey) };
+}
+
+export async function listCronScheduleAudit(jobKey, limit = 20) {
+  const result = await pool.query(
+    `SELECT id, job_key, old_cron_expression, new_cron_expression, old_timezone, new_timezone, changed_by, changed_at
+     FROM cron_schedule_audit
+     WHERE ($1::varchar IS NULL OR job_key = $1)
+     ORDER BY changed_at DESC
+     LIMIT $2`,
+    [jobKey || null, limit],
+  );
+  return result.rows;
+}

--- a/backend/src/lib/admin/cronValidation.js
+++ b/backend/src/lib/admin/cronValidation.js
@@ -1,0 +1,15 @@
+import moment from 'moment-timezone';
+import { validate as validateCronExpression } from 'node-cron';
+
+export function validateCronSchedule(cronExpression, timezone) {
+  if (!cronExpression || typeof cronExpression !== 'string') {
+    return { valid: false, error: 'cronExpression is required' };
+  }
+  if (!validateCronExpression(cronExpression)) {
+    return { valid: false, error: 'Invalid cron expression' };
+  }
+  if (!timezone || !moment.tz.zone(timezone)) {
+    return { valid: false, error: 'Invalid timezone' };
+  }
+  return { valid: true };
+}

--- a/backend/src/syncWorker.js
+++ b/backend/src/syncWorker.js
@@ -1,4 +1,5 @@
 import cron from 'node-cron';
+import { listCronSchedules, getCronSchedule } from './lib/admin/cronSchedules.js';
 import moment from 'moment-timezone';
 import EleringAPI from './elering-api.js';
 import { isDateComplete as checkDateComplete } from './lib/sync/completeness.js';
@@ -53,6 +54,21 @@ class SyncWorker {
     this.dailySyncWatchdogInterval = null; // Watchdog to ensure sync is scheduled
     this.dailySyncFallbackCron = null; // Fallback cron job as safety net
     this.dailyScheduler = new DailySyncScheduler(this);
+    this.cronScheduleConfig = {};
+  }
+
+  async loadCronScheduleConfig() {
+    try {
+      const rows = await listCronSchedules();
+      this.cronScheduleConfig = Object.fromEntries(rows.map((row) => [row.job_key, row]));
+    } catch (error) {
+      console.warn('[Cron Schedules] Failed to load from database, using defaults:', error.message);
+      this.cronScheduleConfig = {};
+    }
+  }
+
+  getCronConfig(jobKey, fallback) {
+    return this.cronScheduleConfig[jobKey] || fallback;
   }
 
   // Start the worker
@@ -70,14 +86,38 @@ class SyncWorker {
     // Check if we need to run a startup sync
     await this.checkStartupSync();
 
+    await this.loadCronScheduleConfig();
+
     // Schedule daily sync that runs every 15 minutes from 12:45 to 16:00 UTC
     this.scheduleDailySync();
-    
-    // Schedule weekly full sync (every Sunday at 2 AM)
-    this.scheduleWeeklySync('0 2 * * 0', 'Weekly Full Sync');
 
-    // Schedule next day sync (every day at 13:30 UTC - after NordPool publishes next day data)
-    this.scheduleNextDaySync('30 13 * * *', 'Next Day Sync');
+    const weeklyConfig = this.getCronConfig('weekly_sync', {
+      cron_expression: '0 2 * * 0',
+      timezone: 'Europe/Vilnius',
+      name: 'Weekly Full Sync',
+      enabled: true,
+    });
+    if (weeklyConfig.enabled !== false) {
+      this.scheduleWeeklySync(
+        weeklyConfig.cron_expression,
+        weeklyConfig.name || 'Weekly Full Sync',
+        weeklyConfig.timezone || 'Europe/Vilnius',
+      );
+    }
+
+    const nextDayConfig = this.getCronConfig('next_day_sync', {
+      cron_expression: '30 13 * * *',
+      timezone: 'Europe/Paris',
+      name: 'Next Day Sync',
+      enabled: true,
+    });
+    if (nextDayConfig.enabled !== false) {
+      this.scheduleNextDaySync(
+        nextDayConfig.cron_expression,
+        nextDayConfig.name || 'Next Day Sync',
+        nextDayConfig.timezone || 'Europe/Paris',
+      );
+    }
 
     // Start health monitoring
     this.startHealthMonitoring();
@@ -1121,7 +1161,12 @@ class SyncWorker {
   }
 
   // Schedule weekly full sync
-  scheduleWeeklySync(cronExpression, description) {
+  scheduleWeeklySync(cronExpression, description, timezone = 'Europe/Vilnius') {
+    if (this.weeklySyncJob) {
+      this.weeklySyncJob.stop();
+      this.weeklySyncJob = null;
+    }
+
     this.weeklySyncJob = cron.schedule(cronExpression, async () => {
       console.log(`[Weekly Sync] Running ${description}...`);
       
@@ -1132,15 +1177,20 @@ class SyncWorker {
       }
     }, {
       scheduled: false,
-      timezone: 'Europe/Vilnius'
+      timezone,
     });
     
     this.weeklySyncJob.start();
-    console.log(`[Weekly Sync] Scheduled: ${cronExpression} (CET)`);
+    console.log(`[Weekly Sync] Scheduled: ${cronExpression} (${timezone})`);
   }
 
   // Schedule next day sync
-  scheduleNextDaySync(cronExpression, description) {
+  scheduleNextDaySync(cronExpression, description, timezone = 'Europe/Paris') {
+    if (this.nextDaySyncJob) {
+      this.nextDaySyncJob.stop();
+      this.nextDaySyncJob = null;
+    }
+
     this.nextDaySyncJob = cron.schedule(cronExpression, async () => {
       console.log(`[Next Day Sync] Running ${description}...`);
       
@@ -1151,11 +1201,45 @@ class SyncWorker {
       }
     }, {
       scheduled: false,
-      timezone: 'Europe/Paris' // CET/CEST timezone
+      timezone,
     });
     
     this.nextDaySyncJob.start();
-    console.log(`[Next Day Sync] Scheduled: ${cronExpression} (CET)`);
+    console.log(`[Next Day Sync] Scheduled: ${cronExpression} (${timezone})`);
+  }
+
+  async reloadCronSchedule(jobKey) {
+    const schedule = await getCronSchedule(jobKey);
+    if (!schedule) {
+      throw new Error(`Unknown cron job: ${jobKey}`);
+    }
+    if (!schedule.editable) {
+      throw new Error(`Cron job ${jobKey} is read-only`);
+    }
+
+    await this.loadCronScheduleConfig();
+
+    if (schedule.enabled === false) {
+      if (jobKey === 'weekly_sync' && this.weeklySyncJob) {
+        this.weeklySyncJob.stop();
+        this.weeklySyncJob = null;
+      }
+      if (jobKey === 'next_day_sync' && this.nextDaySyncJob) {
+        this.nextDaySyncJob.stop();
+        this.nextDaySyncJob = null;
+      }
+      return schedule;
+    }
+
+    if (jobKey === 'weekly_sync') {
+      this.scheduleWeeklySync(schedule.cron_expression, schedule.name, schedule.timezone);
+    } else if (jobKey === 'next_day_sync') {
+      this.scheduleNextDaySync(schedule.cron_expression, schedule.name, schedule.timezone);
+    } else {
+      throw new Error(`Cron job ${jobKey} cannot be reloaded`);
+    }
+
+    return schedule;
   }
 
   // Run weekly sync
@@ -1545,30 +1629,42 @@ class SyncWorker {
   getScheduledJobs() {
     const jobs = [];
     jobs.push(this.dailyScheduler.getDailySyncJobInfo((expr, tz) => this.getNextRunTime(expr, tz)));
-    
-    // Weekly sync job
+
+    const weeklyConfig = this.getCronConfig('weekly_sync', {
+      cron_expression: '0 2 * * 0',
+      timezone: 'Europe/Vilnius',
+      name: 'Weekly Sync',
+    });
     if (this.weeklySyncJob) {
-      const nextRun = this.getNextRunTime('0 2 * * 0', 'Europe/Vilnius');
+      const nextRun = this.getNextRunTime(weeklyConfig.cron_expression, weeklyConfig.timezone);
       jobs.push({
-        name: 'Weekly Sync',
-        cron: '0 2 * * 0',
-        timezone: 'Europe/Vilnius',
-        description: 'Every Sunday at 2 AM CET',
+        jobKey: 'weekly_sync',
+        name: weeklyConfig.name || 'Weekly Sync',
+        cron: weeklyConfig.cron_expression,
+        timezone: weeklyConfig.timezone,
+        description: weeklyConfig.description || 'Every Sunday at 2 AM',
+        editable: weeklyConfig.editable !== false,
         running: this.weeklySyncJob.running,
-        nextRun: nextRun
+        nextRun,
       });
     }
-    
-    // Next day sync job
+
+    const nextDayConfig = this.getCronConfig('next_day_sync', {
+      cron_expression: '30 13 * * *',
+      timezone: 'Europe/Paris',
+      name: 'Next Day Sync',
+    });
     if (this.nextDaySyncJob) {
-      const nextRun = this.getNextRunTime('30 13 * * *', 'Europe/Paris');
+      const nextRun = this.getNextRunTime(nextDayConfig.cron_expression, nextDayConfig.timezone);
       jobs.push({
-        name: 'Next Day Sync',
-        cron: '30 13 * * *',
-        timezone: 'Europe/Paris',
-        description: 'Every day at 13:30 CET',
+        jobKey: 'next_day_sync',
+        name: nextDayConfig.name || 'Next Day Sync',
+        cron: nextDayConfig.cron_expression,
+        timezone: nextDayConfig.timezone,
+        description: nextDayConfig.description || 'Every day at 13:30 Paris time',
+        editable: nextDayConfig.editable !== false,
         running: this.nextDaySyncJob.running,
-        nextRun: nextRun
+        nextRun,
       });
     }
     
@@ -2011,6 +2107,7 @@ const syncWorker = new SyncWorker();
 export const startSyncWorker = () => syncWorker.start();
 export const stopSyncWorker = () => syncWorker.stop();
 export const getSyncStatus = () => syncWorker.getStatus();
+export const reloadCronSchedule = (jobKey) => syncWorker.reloadCronSchedule(jobKey);
 
 // Export the worker instance for direct access
 export default syncWorker; 

--- a/backend/src/test.js
+++ b/backend/src/test.js
@@ -11,6 +11,7 @@ import {
 } from './lib/sync/releaseWindow.js';
 import { getExpectedMtuRange } from './lib/sync/completeness.js';
 import { shouldSuppressDailySyncForToday } from './lib/sync/suppression.js';
+import { validateCronSchedule } from './lib/admin/cronValidation.js';
 
 let passed = 0;
 let failed = 0;
@@ -125,6 +126,21 @@ await testAsync('suppresses only when today and tomorrow are complete', async ()
   assert.equal(suppressed, true);
   assert.ok(worker.dailySyncSuppressedDate);
   clearTimeout(worker.dailySyncTimeout);
+});
+
+test('validateCronSchedule accepts known weekly sync expression', () => {
+  const result = validateCronSchedule('0 2 * * 0', 'Europe/Vilnius');
+  assert.equal(result.valid, true);
+});
+
+test('validateCronSchedule rejects invalid cron expression', () => {
+  const result = validateCronSchedule('not-a-cron', 'Europe/Vilnius');
+  assert.equal(result.valid, false);
+});
+
+test('validateCronSchedule rejects invalid timezone', () => {
+  const result = validateCronSchedule('0 2 * * 0', 'Not/AZone');
+  assert.equal(result.valid, false);
 });
 
 console.log(`\nTest results: ${passed} passed, ${failed} failed`);

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -1,7 +1,13 @@
 import express from 'express';
 import moment from 'moment-timezone';
-import syncWorker from './syncWorker.js';
+import syncWorker, { reloadCronSchedule } from './syncWorker.js';
 import { isInReleaseWindow } from './lib/sync/releaseWindow.js';
+import { requireAdminToken } from './lib/admin/auth.js';
+import {
+  listCronSchedules,
+  listCronScheduleAudit,
+  updateCronSchedule,
+} from './lib/admin/cronSchedules.js';
 import { getPriceData, getPriceDataAll, getLatestPrice, getCurrentPrice, getAvailableCountries, getSettings, updateSetting, getCurrentHourPrice, getLatestPriceAll, getCurrentHourPriceAll, getLatestTimestamp, logSync, getAllEarliestTimestamps, getInitialSyncStatus, getDatabaseStats, getSystemHealth, getAllCountrySyncStatus } from './database.js';
 import pool from './database.js';
 
@@ -1041,6 +1047,82 @@ router.post('/sync/reset-initial', async (req, res) => {
       success: false,
       error: 'Failed to reset initial sync status',
       details: error.message
+    });
+  }
+});
+
+// Admin: cron schedule viewer/editor (API v1)
+router.get('/admin/cron', requireAdminToken, async (req, res) => {
+  try {
+    const schedules = await listCronSchedules();
+    const runtimeJobs = syncWorker.getStatus().scheduledJobs || [];
+    const runtimeByKey = Object.fromEntries(
+      runtimeJobs.filter((job) => job.jobKey).map((job) => [job.jobKey, job]),
+    );
+
+    res.json({
+      success: true,
+      data: schedules.map((schedule) => ({
+        ...schedule,
+        runtime: runtimeByKey[schedule.job_key] || null,
+      })),
+    });
+  } catch (error) {
+    console.error('[Admin] Error listing cron schedules:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to list cron schedules',
+      details: error.message,
+    });
+  }
+});
+
+router.get('/admin/cron/audit', requireAdminToken, async (req, res) => {
+  try {
+    const { jobKey, limit } = req.query;
+    const parsedLimit = Math.min(parseInt(limit, 10) || 20, 100);
+    const rows = await listCronScheduleAudit(jobKey || null, parsedLimit);
+    res.json({ success: true, data: rows });
+  } catch (error) {
+    console.error('[Admin] Error fetching cron audit log:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to fetch cron audit log',
+      details: error.message,
+    });
+  }
+});
+
+router.put('/admin/cron/:jobKey', requireAdminToken, async (req, res) => {
+  try {
+    const { jobKey } = req.params;
+    const { cronExpression, timezone, enabled } = req.body || {};
+    const result = await updateCronSchedule(
+      jobKey,
+      { cronExpression, timezone, enabled },
+      req.adminActor,
+    );
+
+    if (!result.ok) {
+      return res.status(result.status).json({
+        success: false,
+        error: result.error,
+      });
+    }
+
+    await reloadCronSchedule(jobKey);
+
+    res.json({
+      success: true,
+      data: result.schedule,
+      message: 'Cron schedule updated and scheduler reloaded',
+    });
+  } catch (error) {
+    console.error('[Admin] Error updating cron schedule:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to update cron schedule',
+      details: error.message,
     });
   }
 });

--- a/database/init/01_schema.sql
+++ b/database/init/01_schema.sql
@@ -406,3 +406,35 @@ INSERT INTO translations (entity_type, entity_key, locale, translated_label) VAL
 ON CONFLICT (entity_type, entity_key, locale) DO UPDATE
 SET translated_label = EXCLUDED.translated_label,
     updated_at = CURRENT_TIMESTAMP;
+
+-- Admin-editable cron schedules (sync worker jobs)
+CREATE TABLE IF NOT EXISTS cron_schedules (
+    job_key VARCHAR(50) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    cron_expression VARCHAR(100) NOT NULL,
+    timezone VARCHAR(50) NOT NULL DEFAULT 'Europe/Vilnius',
+    description TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    editable BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS cron_schedule_audit (
+    id SERIAL PRIMARY KEY,
+    job_key VARCHAR(50) NOT NULL,
+    old_cron_expression VARCHAR(100),
+    new_cron_expression VARCHAR(100) NOT NULL,
+    old_timezone VARCHAR(50),
+    new_timezone VARCHAR(50) NOT NULL,
+    changed_by VARCHAR(100),
+    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_cron_schedule_audit_job_key ON cron_schedule_audit(job_key);
+
+INSERT INTO cron_schedules (job_key, name, cron_expression, timezone, description, editable) VALUES
+('weekly_sync', 'Weekly Full Sync', '0 2 * * 0', 'Europe/Vilnius', 'Every Sunday at 2 AM Vilnius time', true),
+('next_day_sync', 'Next Day Sync', '30 13 * * *', 'Europe/Paris', 'Every day at 13:30 Paris time after Nord Pool publish window', true),
+('daily_sync', 'Daily Release Window Sync', 'dynamic', 'Europe/Paris', 'Dynamic scheduler during Nord Pool release window (read-only)', false)
+ON CONFLICT (job_key) DO NOTHING;

--- a/swagger-ui/openapi.json
+++ b/swagger-ui/openapi.json
@@ -1967,6 +1967,121 @@
           }
         }
       }
+    },
+    "/admin/cron": {
+      "get": {
+        "summary": "List cron schedules (admin)",
+        "description": "Returns persisted cron schedules merged with runtime sync worker status. Requires ADMIN_API_TOKEN.",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cron schedule list"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "503": {
+            "description": "Admin API not configured"
+          }
+        }
+      }
+    },
+    "/admin/cron/audit": {
+      "get": {
+        "summary": "Cron schedule change audit log (admin)",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "jobKey",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Audit log entries"
+          }
+        }
+      }
+    },
+    "/admin/cron/{jobKey}": {
+      "put": {
+        "summary": "Update cron schedule (admin)",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobKey",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "cronExpression": {
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Schedule updated and scheduler reloaded"
+          },
+          "400": {
+            "description": "Validation error or read-only job"
+          },
+          "404": {
+            "description": "Unknown job key"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2193,6 +2308,13 @@
           "path": "/api/v1/nps/price/lt/latest"
         }
       }
+    },
+    "securitySchemes": {
+      "AdminToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Admin-Token"
+      }
     }
   },
   "tags": [
@@ -2215,6 +2337,10 @@
     {
       "name": "Sync",
       "description": "Sync worker status and admin triggers"
+    },
+    {
+      "name": "Admin",
+      "description": "Protected admin API (ADMIN_API_TOKEN)"
     },
     {
       "name": "Legacy",

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -1312,6 +1312,77 @@ paths:
         '500':
           description: 'Failed to check recent completeness'
 
+  /admin/cron:
+    get:
+      summary: 'List cron schedules (admin)'
+      description: 'Returns persisted cron schedules merged with runtime sync worker status. Requires ADMIN_API_TOKEN.'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      responses:
+        '200':
+          description: 'Cron schedule list'
+        '401':
+          description: 'Unauthorized'
+        '503':
+          description: 'Admin API not configured'
+
+  /admin/cron/audit:
+    get:
+      summary: 'Cron schedule change audit log (admin)'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      parameters:
+        - in: query
+          name: jobKey
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: 'Audit log entries'
+
+  /admin/cron/{jobKey}:
+    put:
+      summary: 'Update cron schedule (admin)'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      parameters:
+        - in: path
+          name: jobKey
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cronExpression:
+                  type: string
+                timezone:
+                  type: string
+                enabled:
+                  type: boolean
+      responses:
+        '200':
+          description: 'Schedule updated and scheduler reloaded'
+        '400':
+          description: 'Validation error or read-only job'
+        '404':
+          description: 'Unknown job key'
+
 components:
   schemas:
     Country:
@@ -1466,6 +1537,11 @@ components:
         code: 'NO_DATA_FOUND'
         timestamp: '2025-06-26T00:15:30.024Z'
         path: '/api/v1/nps/price/lt/latest'
+  securitySchemes:
+    AdminToken:
+      type: apiKey
+      in: header
+      name: X-Admin-Token
 tags:
   - name: Prices
     description: 'Electricity price data endpoints'
@@ -1477,5 +1553,7 @@ tags:
     description: 'Price configuration and tariff endpoints'
   - name: Sync
     description: 'Sync worker status and admin triggers'
+  - name: Admin
+    description: 'Protected admin API (ADMIN_API_TOKEN)'
   - name: Legacy
     description: 'Deprecated compatibility endpoints; prefer /nps/* equivalents'


### PR DESCRIPTION
## Summary
- Add `cron_schedules` and `cron_schedule_audit` tables with default weekly/next-day jobs
- Protected admin routes: `GET /admin/cron`, `PUT /admin/cron/:jobKey`, `GET /admin/cron/audit`
- `ADMIN_API_TOKEN` auth, cron/timezone validation, hot reload via sync worker
- OpenAPI + unit tests for validation helpers

Fixes #13

## Test plan
- [x] `npm test --prefix backend`
- [x] `node bin/openapi-json-from-yaml.js --check`
- [ ] Manual: `curl -H "X-Admin-Token: $ADMIN_API_TOKEN" http://localhost:3000/api/v1/admin/cron`


Made with [Cursor](https://cursor.com)