### PR TITLE
feat(e2e): Playwright smoke suite and post-backlog work loop

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,73 @@
+name: E2E
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Start dev stack
+        env:
+          POSTGRES_PASSWORD: ci_password_change_me
+        run: |
+          cp -n deploy/local.env.example deploy/local.env 2>/dev/null || true
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build db backend frontend
+          for i in $(seq 1 90); do
+            pg_isready -h 127.0.0.1 -p 5432 -U electricity_user && break
+            sleep 2
+          done
+          PGPASSWORD=ci_password_change_me psql -h 127.0.0.1 -U electricity_user -d electricity_prices \
+            -f database/fixtures/ci_seed.sql
+          for i in $(seq 1 90); do
+            curl -sf http://127.0.0.1:3000/health && break
+            sleep 2
+          done
+          curl -sf http://127.0.0.1:3000/health || (echo "backend failed to start" && exit 1)
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:5173/ >/dev/null && break
+            sleep 2
+          done
+          curl -sf http://127.0.0.1:5173/ >/dev/null || (echo "frontend failed to start" && exit 1)
+
+      - name: Install Playwright
+        working-directory: tests/e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run smoke E2E
+        working-directory: tests/e2e
+        env:
+          CI: 'true'
+          FRONTEND_URL: http://127.0.0.1:5173
+          API_URL: http://127.0.0.1:3000
+          SKIP_WEB_SERVER: '1'
+        run: npm test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report/
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ lerna-debug.log*
 # Worktrees and local tooling
 .worktrees/
 
+# Playwright artifacts
+tests/e2e/playwright-report/
+tests/e2e/test-results/
+tests/e2e/blob-report/
+tests/e2e/node_modules/
+
 # DB capture temp files (LFS snapshot path data/db-backup/*.sql.gz is tracked)
 data/db-backup/*.partial
 data/db-backup/*.tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,17 @@ When executing a revamp phase or adoption slice, agents MUST NOT stop after the 
 
 The scope gate applies to each unit of work; the work loop governs sequencing across units.
 
+### Post-backlog phase
+
+When open revamp issues = 0 (or only operator-blocked, e.g. #34 password rotation):
+
+1. **Run full verification** — `docker compose config -q`, backend tests, frontend build, `./bin/smoke-local.sh`
+2. **Run/add E2E (Playwright)** — today, upcoming, settings, legacy API headers; adapt patterns from `vendor/flows/components/e2e-playwright/` (read-only)
+3. **File new issues** for any failures or gaps found (`source:ai`); never stop silently
+4. **Re-enter work loop** on new issues until the next test gate
+
+E2E lives in `tests/e2e/`; local runner `./bin/run-e2e.sh`; CI workflow `.github/workflows/e2e.yml` (scheduled + `workflow_dispatch`, not a required PR gate until stable).
+
 ## Agent roles
 
 | Role | Owns | Exit criteria |

--- a/bin/run-e2e.sh
+++ b/bin/run-e2e.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Playwright smoke against local frontend + API. Requires stack or dev server running.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT}"
+
+if [[ -f deploy/local.env ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  source deploy/local.env
+  set +a
+fi
+
+cd tests/e2e
+
+if [[ ! -d node_modules/@playwright/test ]]; then
+  echo "==> installing Playwright deps"
+  npm ci
+fi
+
+export E2E_BROWSERS="${E2E_BROWSERS:-chromium}"
+echo "==> ensuring Playwright browser: ${E2E_BROWSERS}"
+npx playwright install "${E2E_BROWSERS}"
+
+export FRONTEND_URL="${FRONTEND_URL:-${LOCAL_FRONTEND_URL:-http://127.0.0.1:5173}}"
+export API_URL="${API_URL:-${LOCAL_API_URL:-http://127.0.0.1:3000}}"
+export SKIP_WEB_SERVER="${SKIP_WEB_SERVER:-1}"
+echo "==> Playwright E2E at ${FRONTEND_URL} (API ${API_URL}, SKIP_WEB_SERVER=${SKIP_WEB_SERVER})"
+npm test

--- a/tests/e2e/api.spec.js
+++ b/tests/e2e/api.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+const apiBase = process.env.API_URL || 'http://127.0.0.1:3000';
+
+test.describe('API contracts', () => {
+  test('legacy sync status includes Deprecation header', async ({ request }) => {
+    const response = await request.get(`${apiBase}/api/sync/status`);
+    expect(response.ok()).toBeTruthy();
+    const headers = response.headers();
+    expect(headers.deprecation).toBe('true');
+    expect(headers.link).toMatch(/successor-version/);
+    expect(headers.link).toMatch(/\/api\/v1\/sync\/status/);
+  });
+
+  test('v1 health responds OK', async ({ request }) => {
+    const response = await request.get(`${apiBase}/api/v1/health`);
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.status).toBeTruthy();
+  });
+});

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,61 @@
+{
+  "name": "nordpool-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nordpool-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nordpool-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.FRONTEND_URL || 'http://127.0.0.1:5173';
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: process.env.SKIP_WEB_SERVER
+    ? undefined
+    : {
+        command: 'npm run dev --prefix ../../electricity-prices-build -- --host 127.0.0.1 --port 5173',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('frontend smoke', () => {
+  test('home redirects to upcoming', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/upcoming/);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('today page loads', async ({ page }) => {
+    await page.goto('/today');
+    await expect(page).toHaveURL(/\/today/);
+    await expect(page.locator('h1, h2').first()).toBeVisible();
+  });
+
+  test('settings page loads', async ({ page }) => {
+    await page.goto('/settings?lang=lt');
+    await expect(page.getByRole('heading', { name: 'Nustatymai' })).toBeVisible();
+  });
+
+  test('API health via frontend proxy', async ({ request }) => {
+    const response = await request.get('/api/v1/health');
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body).toHaveProperty('status');
+  });
+});


### PR DESCRIPTION
## Summary
- Add **Post-backlog phase** to `AGENTS.md` work loop: full verification → E2E → file gaps → re-enter loop
- Scaffold `tests/e2e/` Playwright package with smoke specs (upcoming redirect, today, settings, `/api/v1/health` proxy, legacy Deprecation headers)
- Add `bin/run-e2e.sh` local runner and `.github/workflows/e2e.yml` (weekly + `workflow_dispatch`, not a required PR gate)

## Test plan
- [x] `docker compose config -q`
- [x] `npm ci --prefix electricity-prices-build && npm run build --prefix electricity-prices-build`
- [ ] E2E workflow validated on first `workflow_dispatch` after merge (requires Docker stack in CI)

Fixes #77

Made with [Cursor](https://cursor.com)