### PR TITLE
fix(api): demote on-demand GET /nps/prices fetch to backup path (#11)

### DIFF
--- a/backend/src/lib/prices/backupFetchGuard.js
+++ b/backend/src/lib/prices/backupFetchGuard.js
@@ -1,0 +1,48 @@
+const COOLDOWN_MS = 60_000;
+
+/** @type {Map<string, Promise<unknown>>} */
+const inFlight = new Map();
+
+/** @type {Map<string, number>} */
+const lastCompleted = new Map();
+
+export function buildBackupFetchKey({ country, date, start, end }) {
+  const dateKey = date || `${start}:${end}`;
+  const countryKey = country || 'all';
+  return `${countryKey}:${dateKey}`;
+}
+
+/**
+ * Serialize backup vendor fetches per country/date and enforce a cooldown.
+ * @returns {Promise<{ status: 'fetched' | 'waited' | 'rate_limited', result?: unknown, cooldownMs?: number }>}
+ */
+export async function withBackupFetchGuard(key, fetchFn) {
+  const existing = inFlight.get(key);
+  if (existing) {
+    return { status: 'waited', result: await existing };
+  }
+
+  const last = lastCompleted.get(key);
+  if (last != null && Date.now() - last < COOLDOWN_MS) {
+    return { status: 'rate_limited', cooldownMs: COOLDOWN_MS - (Date.now() - last) };
+  }
+
+  const promise = (async () => {
+    try {
+      return await fetchFn();
+    } finally {
+      inFlight.delete(key);
+      lastCompleted.set(key, Date.now());
+    }
+  })();
+
+  inFlight.set(key, promise);
+  const result = await promise;
+  return { status: 'fetched', result };
+}
+
+/** Test helper — clears in-memory guard state. */
+export function resetBackupFetchGuard() {
+  inFlight.clear();
+  lastCompleted.clear();
+}

--- a/backend/src/lib/prices/backupFetchPolicy.js
+++ b/backend/src/lib/prices/backupFetchPolicy.js
@@ -1,0 +1,49 @@
+export const BACKUP_FETCH_TIMEOUT_MS = 15_000;
+
+export function parseAllowBackupFlag(query = {}) {
+  const raw = query.allow_backup ?? query.backup;
+  if (raw == null || raw === '') return false;
+  const normalized = String(raw).toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
+export function isSingleDateRecordCountComplete(recordCount) {
+  if (recordCount >= 90) {
+    return recordCount >= 92 && recordCount <= 100;
+  }
+  if (recordCount > 0) {
+    return recordCount >= 23 && recordCount <= 25;
+  }
+  return false;
+}
+
+export function needsBackupFetch(rawData, date) {
+  if (!rawData.length) return true;
+  if (date) return !isSingleDateRecordCountComplete(rawData.length);
+  return false;
+}
+
+/**
+ * Decide whether the route should call the vendor backup path.
+ */
+export function resolveBackupFetchPlan({ needsLiveFetch, inReleaseWindow, allowBackup }) {
+  if (!needsLiveFetch) {
+    return { attempt: false, reason: 'db_complete' };
+  }
+  if (inReleaseWindow && !allowBackup) {
+    return { attempt: false, reason: 'release_window', returnPartial: true };
+  }
+  if (allowBackup) {
+    return { attempt: true, reason: 'explicit_flag' };
+  }
+  return { attempt: true, reason: 'outside_release_window' };
+}
+
+export function withTimeout(promise, timeoutMs = BACKUP_FETCH_TIMEOUT_MS) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('backup fetch timeout')), timeoutMs);
+    }),
+  ]);
+}

--- a/backend/src/test.js
+++ b/backend/src/test.js
@@ -12,6 +12,17 @@ import {
 import { getExpectedMtuRange } from './lib/sync/completeness.js';
 import { shouldSuppressDailySyncForToday } from './lib/sync/suppression.js';
 import { validateCronSchedule } from './lib/admin/cronValidation.js';
+import {
+  buildBackupFetchKey,
+  resetBackupFetchGuard,
+  withBackupFetchGuard,
+} from './lib/prices/backupFetchGuard.js';
+import {
+  isSingleDateRecordCountComplete,
+  needsBackupFetch,
+  parseAllowBackupFlag,
+  resolveBackupFetchPlan,
+} from './lib/prices/backupFetchPolicy.js';
 
 let passed = 0;
 let failed = 0;
@@ -141,6 +152,54 @@ test('validateCronSchedule rejects invalid cron expression', () => {
 test('validateCronSchedule rejects invalid timezone', () => {
   const result = validateCronSchedule('0 2 * * 0', 'Not/AZone');
   assert.equal(result.valid, false);
+});
+
+test('parseAllowBackupFlag accepts explicit truthy values', () => {
+  assert.equal(parseAllowBackupFlag({ allow_backup: '1' }), true);
+  assert.equal(parseAllowBackupFlag({ backup: 'true' }), true);
+  assert.equal(parseAllowBackupFlag({}), false);
+});
+
+test('needsBackupFetch flags empty and incomplete single-day data', () => {
+  assert.equal(needsBackupFetch([], '2024-06-15'), true);
+  assert.equal(needsBackupFetch([{ timestamp: 1 }], '2024-06-15'), true);
+  assert.equal(needsBackupFetch(Array.from({ length: 24 }, (_, i) => ({ timestamp: i })), '2024-06-15'), false);
+});
+
+test('isSingleDateRecordCountComplete handles hourly and quarter-hour MTU', () => {
+  assert.equal(isSingleDateRecordCountComplete(24), true);
+  assert.equal(isSingleDateRecordCountComplete(23), true);
+  assert.equal(isSingleDateRecordCountComplete(10), false);
+  assert.equal(isSingleDateRecordCountComplete(96), true);
+  assert.equal(isSingleDateRecordCountComplete(90), false);
+});
+
+test('resolveBackupFetchPlan skips backup during release window unless forced', () => {
+  const skipped = resolveBackupFetchPlan({
+    needsLiveFetch: true,
+    inReleaseWindow: true,
+    allowBackup: false,
+  });
+  assert.equal(skipped.attempt, false);
+  assert.equal(skipped.reason, 'release_window');
+
+  const forced = resolveBackupFetchPlan({
+    needsLiveFetch: true,
+    inReleaseWindow: true,
+    allowBackup: true,
+  });
+  assert.equal(forced.attempt, true);
+  assert.equal(forced.reason, 'explicit_flag');
+});
+
+await testAsync('withBackupFetchGuard rate-limits duplicate keys', async () => {
+  resetBackupFetchGuard();
+  const key = buildBackupFetchKey({ country: 'lt', date: '2024-06-15' });
+  const first = await withBackupFetchGuard(key, async () => 'ok');
+  assert.equal(first.status, 'fetched');
+  const second = await withBackupFetchGuard(key, async () => 'again');
+  assert.equal(second.status, 'rate_limited');
+  resetBackupFetchGuard();
 });
 
 console.log(`\nTest results: ${passed} passed, ${failed} failed`);

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -2,6 +2,16 @@ import express from 'express';
 import moment from 'moment-timezone';
 import syncWorker, { reloadCronSchedule } from './syncWorker.js';
 import { isInReleaseWindow } from './lib/sync/releaseWindow.js';
+import {
+  buildBackupFetchKey,
+  withBackupFetchGuard,
+} from './lib/prices/backupFetchGuard.js';
+import {
+  needsBackupFetch,
+  parseAllowBackupFlag,
+  resolveBackupFetchPlan,
+  withTimeout,
+} from './lib/prices/backupFetchPolicy.js';
 import { requireAdminToken } from './lib/admin/auth.js';
 import {
   listCronSchedules,
@@ -213,6 +223,7 @@ router.get('/nps/price/:country/current', async (req, res) => {
 router.get('/nps/prices', async (req, res) => {
   try {
     let { date, start, end, country } = req.query;
+    const allowBackup = parseAllowBackupFlag(req.query);
     const requestedAll = !country;
     country = (country || '').toLowerCase();
     
@@ -287,129 +298,153 @@ router.get('/nps/prices', async (req, res) => {
     // Nordpool release window. On-demand Elering fetch below is a fallback when DB
     // data is missing or incomplete outside that window.
     let dataSource = 'db';
-    let needsLiveFetch = false;
-    if (rawData.length === 0) {
-      needsLiveFetch = true;
-    } else if (date) {
-      // For single date, check if we have sufficient records
-      // Expected: 23-25 for 60-min MTU (accounting for DST), 92-100 for 15-min MTU (accounting for DST)
-      // Use the same logic as isDateComplete: check if count is within expected range
-      const recordCount = rawData.length;
-      let isComplete = false;
-      
-      if (recordCount >= 90) {
-        // 15-minute MTU: expect 92-100 records (accounting for DST)
-        isComplete = recordCount >= 92 && recordCount <= 100;
-      } else if (recordCount > 0) {
-        // 60-minute MTU: expect 23-25 records (accounting for DST)
-        isComplete = recordCount >= 23 && recordCount <= 25;
+    let backupSkippedReason = null;
+    const releaseWindowActive = isInReleaseWindow();
+    const needsLiveFetch = needsBackupFetch(rawData, date);
+    const backupPlan = resolveBackupFetchPlan({
+      needsLiveFetch,
+      inReleaseWindow: releaseWindowActive,
+      allowBackup,
+    });
+
+    if (needsLiveFetch && !backupPlan.attempt) {
+      console.log(`[Backup Fetch] Skipped (${backupPlan.reason}) — sync worker owns ingestion for ${date || `${start} to ${end}`}`);
+      backupSkippedReason = backupPlan.reason;
+      if (rawData.length === 0) {
+        return res.status(404).json({
+          success: false,
+          error: 'No price data found for the specified date range',
+          code: 'NO_DATA_FOUND',
+          meta: {
+            dataSource: 'partial',
+            releaseWindowActive,
+            backupSkippedReason,
+            dbRecordCount: 0,
+          },
+        });
       }
-      
-      if (!isComplete) {
-        needsLiveFetch = true;
-        console.log(`[On-Demand Fetch] Insufficient data for ${date}: found ${recordCount} records, expected 23-25 (60-min) or 92-100 (15-min)`);
-      }
-    }
-    
-    // If no data found or insufficient data, try backup fetch from Elering API
-    if (needsLiveFetch) {
-      if (isInReleaseWindow()) {
-        console.log(`[Backup Fetch] Skipped during release window — sync worker owns ingestion for ${date || `${start} to ${end}`}`);
-        if (rawData.length === 0) {
-          return res.status(404).json({
-            success: false,
-            error: 'No price data found for the specified date range',
-            code: 'NO_DATA_FOUND',
-            meta: { dataSource: 'partial', releaseWindowActive: true }
-          });
-        }
-        dataSource = 'partial';
-      } else {
-      console.log(`[Backup Fetch] No or insufficient data in DB for ${date || `${start} to ${end}`} (${country || 'all'}), attempting live fetch...`);
-      
+      dataSource = 'partial';
+    } else if (backupPlan.attempt) {
+      const backupKey = buildBackupFetchKey({ country, date, start, end });
+      console.log(`[Backup Fetch] Attempting vendor backup (${backupPlan.reason}) for ${date || `${start} to ${end}`} (${country || 'all'})`);
+
       try {
-        // Determine date range for fetch
-        let fetchStartDate, fetchEndDate;
-        if (date) {
-          fetchStartDate = moment.tz(date, "Europe/Vilnius").format('YYYY-MM-DD');
-          fetchEndDate = fetchStartDate;
-        } else if (start && end) {
-          fetchStartDate = moment.tz(start, "Europe/Vilnius").format('YYYY-MM-DD');
-          fetchEndDate = moment.tz(end, "Europe/Vilnius").format('YYYY-MM-DD');
-        } else {
-          return res.status(404).json({ 
-            success: false,
-            error: 'No price data found for the specified date range',
-            code: 'NO_DATA_FOUND'
-          });
-        }
-        
-        // Fetch data from Elering API
-        const eleringApi = syncWorker.api;
-        if (requestedAll) {
-          // Fetch all countries
-          const allCountriesData = await eleringApi.fetchAllCountriesData(fetchStartDate, fetchEndDate);
-          
-          // Store in database
-          for (const [countryCode, countryData] of Object.entries(allCountriesData)) {
-            if (countryData && countryData.length > 0) {
-              await syncWorker.insertPriceData(countryData, countryCode);
+        const guardResult = await withBackupFetchGuard(backupKey, async () => {
+          let fetchStartDate;
+          let fetchEndDate;
+          if (date) {
+            fetchStartDate = moment.tz(date, 'Europe/Vilnius').format('YYYY-MM-DD');
+            fetchEndDate = fetchStartDate;
+          } else if (start && end) {
+            fetchStartDate = moment.tz(start, 'Europe/Vilnius').format('YYYY-MM-DD');
+            fetchEndDate = moment.tz(end, 'Europe/Vilnius').format('YYYY-MM-DD');
+          } else {
+            return { ok: false, code: 'NO_DATA_FOUND' };
+          }
+
+          const eleringApi = syncWorker.api;
+          if (requestedAll) {
+            const allCountriesData = await withTimeout(
+              eleringApi.fetchAllCountriesData(fetchStartDate, fetchEndDate),
+            );
+            for (const [countryCode, countryData] of Object.entries(allCountriesData)) {
+              if (countryData && countryData.length > 0) {
+                await syncWorker.insertPriceData(countryData, countryCode);
+              }
             }
+            return { ok: true, rows: await getPriceDataAll(startDate, endDate) };
           }
-          
-          // Re-query database
-          rawData = await getPriceDataAll(startDate, endDate);
-        } else {
-          // Fetch single country
-          const countryData = await eleringApi.fetchPricesForRange(fetchStartDate, fetchEndDate, country);
-          
+
+          const countryData = await withTimeout(
+            eleringApi.fetchPricesForRange(fetchStartDate, fetchEndDate, country),
+          );
           if (countryData && countryData.length > 0) {
-            // Store in database
             await syncWorker.insertPriceData(countryData, country);
-            
-            // Re-query database
-            rawData = await getPriceData(startDate, endDate, country);
+            return { ok: true, rows: await getPriceData(startDate, endDate, country) };
+          }
+          return { ok: true, rows: [] };
+        });
+
+        if (guardResult.status === 'rate_limited') {
+          backupSkippedReason = 'rate_limited';
+          if (rawData.length === 0) {
+            return res.status(503).json({
+              success: false,
+              error: 'Backup fetch temporarily rate-limited; retry shortly',
+              code: 'BACKUP_RATE_LIMITED',
+              meta: {
+                dataSource: 'partial',
+                releaseWindowActive,
+                backupSkippedReason,
+                backupCooldownMs: guardResult.cooldownMs,
+                dbRecordCount: 0,
+              },
+            });
+          }
+          dataSource = 'partial';
+        } else {
+          const fetchOutcome = guardResult.result;
+          if (fetchOutcome?.ok === false && fetchOutcome.code === 'NO_DATA_FOUND') {
+            return res.status(404).json({
+              success: false,
+              error: 'No price data found for the specified date range',
+              code: 'NO_DATA_FOUND',
+            });
+          }
+
+          let refreshedRows = fetchOutcome?.rows || rawData;
+          if (date) {
+            const dateStart = moment.tz(date, 'Europe/Vilnius').startOf('day').unix();
+            const dateEnd = moment.tz(date, 'Europe/Vilnius').endOf('day').unix();
+            refreshedRows = refreshedRows.filter((item) => item.timestamp >= dateStart && item.timestamp <= dateEnd);
+          } else if (start && end) {
+            const rangeStart = moment.tz(start, 'Europe/Vilnius').startOf('day').unix();
+            const rangeEnd = moment.tz(end, 'Europe/Vilnius').endOf('day').unix();
+            refreshedRows = refreshedRows.filter((item) => item.timestamp >= rangeStart && item.timestamp <= rangeEnd);
+          }
+
+          if (refreshedRows.length === 0) {
+            if (rawData.length > 0) {
+              dataSource = 'partial';
+              backupSkippedReason = 'vendor_empty';
+            } else {
+              return res.status(404).json({
+                success: false,
+                error: 'No price data available from Elering API for the specified date range',
+                code: 'NO_DATA_FOUND',
+                meta: {
+                  dataSource: 'partial',
+                  releaseWindowActive,
+                  backupSkippedReason: 'vendor_empty',
+                  dbRecordCount: 0,
+                },
+              });
+            }
+          } else {
+            rawData = refreshedRows;
+            dataSource = 'vendor_backup';
+            console.log(`[Backup Fetch] Served ${rawData.length} records (${guardResult.status})`);
           }
         }
-        
-        // Filter re-queried data to only include requested date(s) in Vilnius timezone
-        if (date) {
-          const dateStart = moment.tz(date, "Europe/Vilnius").startOf('day').unix();
-          const dateEnd = moment.tz(date, "Europe/Vilnius").endOf('day').unix();
-          rawData = rawData.filter(item => 
-            item.timestamp >= dateStart && item.timestamp <= dateEnd
-          );
-        } else if (start && end) {
-          const rangeStart = moment.tz(start, "Europe/Vilnius").startOf('day').unix();
-          const rangeEnd = moment.tz(end, "Europe/Vilnius").endOf('day').unix();
-          rawData = rawData.filter(item => 
-            item.timestamp >= rangeStart && item.timestamp <= rangeEnd
-          );
-        }
-        
-        if (rawData.length === 0) {
-          return res.status(404).json({ 
-            success: false,
-            error: 'No price data available from Elering API for the specified date range',
-            code: 'NO_DATA_FOUND'
-          });
-        }
-        
-        console.log(`[Backup Fetch] Successfully fetched and stored ${rawData.length} records`);
-        dataSource = 'vendor_backup';
       } catch (error) {
-        console.error(`[Backup Fetch] Error fetching data from Elering API:`, error.message);
+        console.error('[Backup Fetch] Error fetching data from Elering API:', error.message);
+        backupSkippedReason = error.message.includes('timeout') ? 'timeout' : 'vendor_error';
         if (rawData.length > 0) {
           dataSource = 'partial';
         } else {
-        return res.status(500).json({ 
-          success: false,
-          error: 'Failed to fetch data from Elering API',
-          code: 'FETCH_ERROR',
-          details: error.message
-        });
+          return res.status(500).json({
+            success: false,
+            error: 'Failed to fetch data from Elering API',
+            code: 'FETCH_ERROR',
+            details: error.message,
+            meta: {
+              dataSource: 'partial',
+              releaseWindowActive,
+              backupSkippedReason,
+              dbRecordCount: 0,
+            },
+          });
         }
-      }
       }
     }
     
@@ -450,7 +485,9 @@ router.get('/nps/prices', async (req, res) => {
         timezone: 'Europe/Vilnius',
         intervalSeconds,
         dataSource,
-        releaseWindowActive: isInReleaseWindow()
+        releaseWindowActive,
+        dbRecordCount: rawData.length,
+        ...(backupSkippedReason ? { backupSkippedReason } : {}),
       }
     });
   } catch (error) {

--- a/swagger-ui/openapi.json
+++ b/swagger-ui/openapi.json
@@ -376,7 +376,7 @@
     "/nps/prices": {
       "get": {
         "summary": "Get price data for date or date range",
-        "description": "Retrieve electricity prices for a specific date or date range.\n\n**Features:**\n- Single date or date range queries\n- Multi-country support (LT, EE, LV, FI)\n- DST-aware timestamp handling\n- Optimized database queries\n\n**Data source:** Primary ingestion is the background sync worker. When the database\nis empty or incomplete for the requested date, this endpoint may perform a one-time\nbackup fetch from the Elering API before responding (see issue #11 for demotion plan).\n\n**Usage Examples:**\n- Single day: `?date=2025-06-26&country=lt`\n- Date range: `?start=2025-06-01&end=2025-06-30&country=ee`\n- All countries: `?date=2025-06-26` (omitting country parameter returns data for all countries)\n\n**Response Format:**\n- One record per Market Time Unit (MTU) for each day (typically 24 records for 60-minute data, or 96 records for 15-minute MTU)\n- Prices in EUR/MWh\n- Unix timestamps (seconds) for easy processing\n",
+        "description": "Retrieve electricity prices for a specific date or date range.\n\n**Features:**\n- Single date or date range queries\n- Multi-country support (LT, EE, LV, FI)\n- DST-aware timestamp handling\n- Optimized database queries\n\n**Data source:** Primary ingestion is the background sync worker during the Nordpool\nrelease window (12:45–15:55 Europe/Paris). When the database is empty or incomplete,\nthis endpoint may perform a rate-limited backup fetch from the Elering API **outside**\nthe release window. Pass `allow_backup=1` to force backup during the release window.\n\n**Response metadata (`meta.dataSource`):**\n- `db` — served from database only\n- `vendor_backup` — vendor fetch supplemented missing rows\n- `partial` — incomplete DB data; backup skipped, failed, or rate-limited\n\n**Usage Examples:**\n- Single day: `?date=2025-06-26&country=lt`\n- Date range: `?start=2025-06-01&end=2025-06-30&country=ee`\n- All countries: `?date=2025-06-26` (omitting country parameter returns data for all countries)\n\n**Response Format:**\n- One record per Market Time Unit (MTU) for each day (typically 24 records for 60-minute data, or 96 records for 15-minute MTU)\n- Prices in EUR/MWh\n- Unix timestamps (seconds) for easy processing\n",
         "tags": [
           "Prices"
         ],
@@ -424,6 +424,19 @@
               ]
             },
             "description": "Country code (case insensitive). If omitted, returns data for all countries."
+          },
+          {
+            "name": "allow_backup",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "true",
+                "yes"
+              ]
+            },
+            "description": "Force vendor backup fetch even during the Nordpool release window (default: skip backup in-window)."
           }
         ],
         "responses": {
@@ -471,6 +484,30 @@
                           "type": "integer",
                           "description": "Market Time Unit length in seconds (e.g. 3600 for hourly, 900 for 15-minute MTU)",
                           "example": 900
+                        },
+                        "dataSource": {
+                          "type": "string",
+                          "enum": [
+                            "db",
+                            "vendor_backup",
+                            "partial"
+                          ],
+                          "description": "How the response was assembled",
+                          "example": "db"
+                        },
+                        "releaseWindowActive": {
+                          "type": "boolean",
+                          "description": "Whether the Nordpool release window was active when the request was handled",
+                          "example": false
+                        },
+                        "backupSkippedReason": {
+                          "type": "string",
+                          "description": "Present when backup was skipped or failed (e.g. release_window, rate_limited, timeout)"
+                        },
+                        "dbRecordCount": {
+                          "type": "integer",
+                          "description": "Number of records returned from the database layer",
+                          "example": 24
                         },
                         "total_records": {
                           "type": "integer",

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -264,9 +264,15 @@ paths:
         - DST-aware timestamp handling
         - Optimized database queries
         
-        **Data source:** Primary ingestion is the background sync worker. When the database
-        is empty or incomplete for the requested date, this endpoint may perform a one-time
-        backup fetch from the Elering API before responding (see issue #11 for demotion plan).
+        **Data source:** Primary ingestion is the background sync worker during the Nordpool
+        release window (12:45–15:55 Europe/Paris). When the database is empty or incomplete,
+        this endpoint may perform a rate-limited backup fetch from the Elering API **outside**
+        the release window. Pass `allow_backup=1` to force backup during the release window.
+        
+        **Response metadata (`meta.dataSource`):**
+        - `db` — served from database only
+        - `vendor_backup` — vendor fetch supplemented missing rows
+        - `partial` — incomplete DB data; backup skipped, failed, or rate-limited
         
         **Usage Examples:**
         - Single day: `?date=2025-06-26&country=lt`
@@ -307,6 +313,12 @@ paths:
             type: string
             enum: [lt, ee, lv, fi]
           description: 'Country code (case insensitive). If omitted, returns data for all countries.'
+        - name: allow_backup
+          in: query
+          schema:
+            type: string
+            enum: ['1', 'true', 'yes']
+          description: 'Force vendor backup fetch even during the Nordpool release window (default: skip backup in-window).'
       responses:
         '200':
           description: 'Price data for the specified period'
@@ -344,6 +356,22 @@ paths:
                         type: integer
                         description: 'Market Time Unit length in seconds (e.g. 3600 for hourly, 900 for 15-minute MTU)'
                         example: 900
+                      dataSource:
+                        type: string
+                        enum: [db, vendor_backup, partial]
+                        description: 'How the response was assembled'
+                        example: db
+                      releaseWindowActive:
+                        type: boolean
+                        description: 'Whether the Nordpool release window was active when the request was handled'
+                        example: false
+                      backupSkippedReason:
+                        type: string
+                        description: 'Present when backup was skipped or failed (e.g. release_window, rate_limited, timeout)'
+                      dbRecordCount:
+                        type: integer
+                        description: 'Number of records returned from the database layer'
+                        example: 24
                       total_records:
                         type: integer
                         example: 24


### PR DESCRIPTION
## Summary
- Demote Elering on-demand fetch on `GET /api/v1/nps/prices` to a rate-limited backup path outside the Nordpool release window
- Add `allow_backup` query flag to force vendor fetch during the release window
- Return `meta.dataSource` (`db` | `vendor_backup` | `partial`) with freshness hints when backup is skipped, rate-limited, or times out
- Document backup semantics and new metadata in OpenAPI

Fixes #11

## Test plan
- [x] `npm test --prefix backend` (17 passed)
- [x] `node bin/openapi-json-from-yaml.js --check`
- [x] `node bin/validate-openapi-routes.js`
- [ ] CI lint-and-unit + integration-golden

Made with [Cursor](https://cursor.com)