### PR TITLE
feat(ops): adopt flows backup-restore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ data/db-backup/*.partial
 data/db-backup/*.tmp
 data/db-backup/*.sql.gz.tmp
 
+# Host Postgres backups (server-backup.sh output)
+backups/
+
 # Legacy paths (kept for compatibility)
 /electricity-prices
 /index.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ After initial sync completes, capture a portable Postgres dump for dev/CI fixtur
 git lfs install && git add data/db-backup/price-data.sql.gz && git commit
 ```
 
-LFS path: `data/db-backup/*.sql.gz`. Details: [docs/ops/db-backup-lfs.md](docs/ops/db-backup-lfs.md).
+LFS path: `data/db-backup/*.sql.gz`. Capture: [docs/ops/db-backup-lfs.md](docs/ops/db-backup-lfs.md). Restore and server cron: [docs/ops/backup-restore.md](docs/ops/backup-restore.md) (`bin/restore-db-lfs.sh`, `bin/server-backup.sh`).
 
 ## Scope gate
 

--- a/bin/capture-db-lfs.sh
+++ b/bin/capture-db-lfs.sh
@@ -153,7 +153,8 @@ Verify:
   git lfs ls-files
   git lfs track
 
-Restore locally: docs/ops/db-backup-lfs.md
+Restore locally: ./bin/restore-db-lfs.sh --fresh-volume
+See: docs/ops/backup-restore.md
 EOF
 }
 

--- a/bin/restore-db-lfs.sh
+++ b/bin/restore-db-lfs.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Restore Git LFS Postgres fixture (plain SQL gzip) into compose db service.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f deploy/local.env ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  source deploy/local.env
+  set +a
+fi
+
+POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
+POSTGRES_USER="${POSTGRES_USER:-electricity_user}"
+DUMP_FILE="${ROOT}/data/db-backup/price-data.sql.gz"
+FRESH_VOLUME=false
+VERIFY_ONLY=false
+START_STACK=true
+
+COMPOSE=(docker compose -f docker-compose.yml)
+if [[ -f docker-compose.dev.yml ]]; then
+  COMPOSE+=(-f docker-compose.dev.yml)
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: bin/restore-db-lfs.sh [OPTIONS]
+
+Restore data/db-backup/price-data.sql.gz into the compose db service.
+
+Options:
+  --fresh-volume   Stop stack, remove postgres_data volume, start db only (destructive)
+  --verify-only    Run verification queries; no restore
+  --dump-file PATH Override LFS fixture path
+  --no-start       Do not start full stack after restore (db only when --fresh-volume)
+  -h, --help       Show this help
+
+Requires: docker compose, db service running (or use --fresh-volume).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fresh-volume)
+      FRESH_VOLUME=true
+      shift
+      ;;
+    --verify-only)
+      VERIFY_ONLY=true
+      shift
+      ;;
+    --dump-file)
+      DUMP_FILE="${2:?--dump-file requires path}"
+      shift 2
+      ;;
+    --no-start)
+      START_STACK=false
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+db_container_running() {
+  "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx 'db'
+}
+
+wait_for_db() {
+  local retries=30
+  echo "Waiting for Postgres (db service)..."
+  while [[ "$retries" -gt 0 ]]; do
+    if "${COMPOSE[@]}" exec -T db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+    retries=$((retries - 1))
+  done
+  echo "Timed out waiting for Postgres" >&2
+  return 1
+}
+
+find_postgres_volume() {
+  docker volume ls -q --filter name=postgres_data 2>/dev/null | head -1
+}
+
+reset_public_schema() {
+  echo "==> Reset public schema before restore"
+  "${COMPOSE[@]}" exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 <<'SQL'
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO CURRENT_USER;
+GRANT ALL ON SCHEMA public TO public;
+SQL
+}
+
+verify_restore() {
+  echo "==> Verification queries"
+  "${COMPOSE[@]}" exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 <<'SQL'
+SELECT current_database() AS db, now() AS verified_at;
+SELECT count(*) AS public_tables FROM information_schema.tables WHERE table_schema = 'public';
+SELECT count(*) AS price_rows FROM price_data;
+SELECT setting_value AS initial_sync_completed
+  FROM user_settings WHERE setting_key = 'initial_sync_completed' LIMIT 1;
+SQL
+}
+
+if [[ "$VERIFY_ONLY" == true ]]; then
+  if ! db_container_running; then
+    echo "db service is not running" >&2
+    exit 1
+  fi
+  verify_restore
+  exit 0
+fi
+
+if [[ ! -f "$DUMP_FILE" ]]; then
+  echo "Dump file not found: $DUMP_FILE" >&2
+  echo "Run: git lfs pull" >&2
+  exit 1
+fi
+
+if [[ ! -s "$DUMP_FILE" ]]; then
+  echo "Dump file is empty: $DUMP_FILE" >&2
+  exit 1
+fi
+
+if [[ "$FRESH_VOLUME" == true ]]; then
+  echo "==> Stopping stack and removing postgres_data volume (destructive)"
+  "${COMPOSE[@]}" down
+  volume_name="$(find_postgres_volume || true)"
+  if [[ -n "$volume_name" ]]; then
+    docker volume rm "$volume_name"
+    echo "Removed volume: $volume_name"
+  fi
+  echo "==> Starting db service"
+  "${COMPOSE[@]}" up -d db
+  wait_for_db
+else
+  if ! db_container_running; then
+    echo "db service is not running. Start stack or use --fresh-volume:" >&2
+    echo "  docker compose up -d db" >&2
+    exit 1
+  fi
+  wait_for_db
+fi
+
+reset_public_schema
+
+echo "==> Restoring ${DUMP_FILE}"
+gunzip -c "$DUMP_FILE" | "${COMPOSE[@]}" exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1
+
+verify_restore
+
+if [[ "$FRESH_VOLUME" == true && "$START_STACK" == true ]]; then
+  echo "==> Starting full stack"
+  "${COMPOSE[@]}" up -d
+fi
+
+cat <<EOF
+
+==> Restore complete
+
+Smoke check:
+  curl -s http://127.0.0.1:3000/health
+  ./bin/smoke-local.sh
+
+See docs/ops/backup-restore.md
+EOF

--- a/bin/server-backup.sh
+++ b/bin/server-backup.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Postgres backup via docker compose (or docker exec) with timestamp and retention.
+# Adapted from vendor/flows/components/backup-restore/server-backup.example.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f deploy/local.env ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  source deploy/local.env
+  set +a
+fi
+
+POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
+POSTGRES_USER="${POSTGRES_USER:-electricity_user}"
+DB_CONTAINER="${DB_CONTAINER:-electricity_db}"
+BACKUP_DIR="${BACKUP_DIR:-${ROOT}/backups/postgres}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+RETENTION_WEEKS="${RETENTION_WEEKS:-4}"
+
+COMPOSE=(docker compose -f docker-compose.yml)
+if [[ -f docker-compose.dev.yml ]]; then
+  COMPOSE+=(-f docker-compose.dev.yml)
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: bin/server-backup.sh
+
+Create a pg_dump custom-format backup with daily/weekly retention.
+
+Env:
+  BACKUP_DIR       Backup root (default: ./backups/postgres)
+  POSTGRES_DB      Database name
+  POSTGRES_USER    Database user
+  DB_CONTAINER     Container name for docker exec (default: electricity_db)
+  RETENTION_DAYS   Daily retention (default: 7)
+  RETENTION_WEEKS  Weekly retention (default: 4)
+  USE_COMPOSE=0    Force docker exec via DB_CONTAINER instead of compose exec
+
+Uses compose exec db when the db service is running; otherwise docker exec DB_CONTAINER.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+daily_dir="${BACKUP_DIR}/daily"
+weekly_dir="${BACKUP_DIR}/weekly"
+mkdir -p "$daily_dir" "$weekly_dir"
+
+daily_file="${daily_dir}/${POSTGRES_DB}-${timestamp}.dump"
+
+run_pg_dump() {
+  local dest="$1"
+  if [[ "${USE_COMPOSE:-1}" != "0" ]] && "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx 'db'; then
+    echo "Backing up via docker compose exec (db service) -> ${dest}"
+    "${COMPOSE[@]}" exec -T db pg_dump \
+      -U "$POSTGRES_USER" \
+      -d "$POSTGRES_DB" \
+      -Fc \
+      --no-owner \
+      --no-acl \
+      > "$dest"
+    return 0
+  fi
+
+  if ! docker inspect "$DB_CONTAINER" >/dev/null 2>&1; then
+    echo "ERROR: db service not running and container not found: $DB_CONTAINER" >&2
+    echo "Start stack: docker compose up -d db" >&2
+    exit 1
+  fi
+
+  echo "Backing up via docker exec ${DB_CONTAINER} -> ${dest}"
+  docker exec "$DB_CONTAINER" pg_dump \
+    -U "$POSTGRES_USER" \
+    -d "$POSTGRES_DB" \
+    -Fc \
+    --no-owner \
+    --no-acl \
+    > "$dest"
+}
+
+run_pg_dump "$daily_file"
+
+if [[ ! -s "$daily_file" ]]; then
+  echo "ERROR: backup file is empty: $daily_file" >&2
+  exit 1
+fi
+
+size_bytes="$(wc -c < "$daily_file" | tr -d ' ')"
+echo "OK: wrote ${daily_file} (${size_bytes} bytes)"
+
+# Weekly snapshot on Sunday (copy daily, do not re-dump)
+if [[ "$(date +%u)" -eq 7 ]]; then
+  weekly_file="${weekly_dir}/${POSTGRES_DB}-${timestamp}.dump"
+  cp "$daily_file" "$weekly_file"
+  echo "Weekly copy: ${weekly_file}"
+fi
+
+find "$daily_dir" -type f -name '*.dump' -mtime +"$RETENTION_DAYS" -print -delete || true
+
+weekly_cutoff_days=$((RETENTION_WEEKS * 7))
+find "$weekly_dir" -type f -name '*.dump' -mtime +"$weekly_cutoff_days" -print -delete || true
+
+echo "Retention applied: daily>${RETENTION_DAYS}d weekly>${RETENTION_WEEKS}w"

--- a/bin/server-restore-drill.sh
+++ b/bin/server-restore-drill.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Non-destructive Postgres restore drill: temp DB, pg_restore, verify, drop.
+# Adapted from vendor/flows/components/backup-restore/server-restore.example.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f deploy/local.env ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  source deploy/local.env
+  set +a
+fi
+
+POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
+POSTGRES_USER="${POSTGRES_USER:-electricity_user}"
+DB_CONTAINER="${DB_CONTAINER:-electricity_db}"
+DUMP_FILE="${DUMP_FILE:-}"
+
+COMPOSE=(docker compose -f docker-compose.yml)
+if [[ -f docker-compose.dev.yml ]]; then
+  COMPOSE+=(-f docker-compose.dev.yml)
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: bin/server-restore-drill.sh
+
+Non-destructive restore drill into a temporary database.
+
+Env:
+  DUMP_FILE        Path to pg_dump custom-format (.dump) file (required)
+  POSTGRES_DB      Production database name (not modified)
+  POSTGRES_USER    Database user
+  DB_CONTAINER     Container for docker exec fallback
+  USE_COMPOSE=0    Force docker exec via DB_CONTAINER
+
+Example:
+  DUMP_FILE=backups/postgres/daily/electricity_prices-20260615-030000.dump ./bin/server-restore-drill.sh
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "$DUMP_FILE" ]]; then
+  echo "ERROR: set DUMP_FILE to a pg_dump custom-format (.dump) file" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -f "$DUMP_FILE" ]]; then
+  echo "ERROR: dump file not found: $DUMP_FILE" >&2
+  exit 1
+fi
+
+use_compose=false
+if [[ "${USE_COMPOSE:-1}" != "0" ]] && "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx 'db'; then
+  use_compose=true
+elif ! docker inspect "$DB_CONTAINER" >/dev/null 2>&1; then
+  echo "ERROR: db service not running and container not found: $DB_CONTAINER" >&2
+  exit 1
+fi
+
+drill_db="restore_drill_$(date +%Y%m%d_%H%M%S)"
+
+psql_admin() {
+  if [[ "$use_compose" == true ]]; then
+    "${COMPOSE[@]}" exec -T db psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 "$@"
+  else
+    docker exec "$DB_CONTAINER" psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 "$@"
+  fi
+}
+
+pg_restore_drill() {
+  if [[ "$use_compose" == true ]]; then
+    "${COMPOSE[@]}" exec -T db pg_restore \
+      -U "$POSTGRES_USER" \
+      -d "$drill_db" \
+      --no-owner \
+      --no-acl \
+      --verbose \
+      < "$DUMP_FILE"
+  else
+    docker exec -i "$DB_CONTAINER" pg_restore \
+      -U "$POSTGRES_USER" \
+      -d "$drill_db" \
+      --no-owner \
+      --no-acl \
+      --verbose \
+      < "$DUMP_FILE"
+  fi
+}
+
+psql_drill_sql() {
+  if [[ "$use_compose" == true ]]; then
+    "${COMPOSE[@]}" exec -T db psql -U "$POSTGRES_USER" -d "$drill_db" -v ON_ERROR_STOP=1
+  else
+    docker exec -i "$DB_CONTAINER" psql -U "$POSTGRES_USER" -d "$drill_db" -v ON_ERROR_STOP=1
+  fi
+}
+
+echo "Creating drill database: ${drill_db}"
+psql_admin -c "CREATE DATABASE \"${drill_db}\";"
+
+cleanup() {
+  echo "Dropping drill database: ${drill_db}"
+  psql_admin -c "DROP DATABASE IF EXISTS \"${drill_db}\";" || true
+}
+trap cleanup EXIT
+
+echo "Restoring ${DUMP_FILE} into ${drill_db}"
+pg_restore_drill
+
+echo "Verification queries on ${drill_db}"
+psql_drill_sql <<'SQL'
+SELECT current_database() AS db, now() AS verified_at;
+SELECT count(*) AS public_tables FROM information_schema.tables WHERE table_schema = 'public';
+SELECT count(*) AS price_rows FROM price_data;
+SELECT setting_value AS initial_sync_completed
+  FROM user_settings WHERE setting_key = 'initial_sync_completed' LIMIT 1;
+SQL
+
+echo "Drill complete. Production database ${POSTGRES_DB} was not modified."

--- a/data/db-backup/README.md
+++ b/data/db-backup/README.md
@@ -10,4 +10,4 @@ This directory is tracked via Git LFS. The snapshot file is not committed until 
 
 **Capture:** `./bin/capture-db-lfs.sh`
 
-**Restore (local dev):** see [docs/ops/db-backup-lfs.md](../docs/ops/db-backup-lfs.md)
+**Restore (local dev):** `./bin/restore-db-lfs.sh --fresh-volume` — see [docs/ops/backup-restore.md](../docs/ops/backup-restore.md)

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -1,0 +1,156 @@
+# Backup and restore runbook
+
+Operational reference for Nordpool Postgres. Patterns adapted from flows `vendor/flows/components/backup-restore/` and [backup-restore-small-team.md](../../vendor/flows/docs/solutions/backup-restore-small-team.md).
+
+## Two tiers
+
+| Tier | Purpose | Format | Script |
+| --- | --- | --- | --- |
+| **Git LFS fixture** | Dev/CI portable snapshot after initial sync | Plain SQL, gzip | `bin/capture-db-lfs.sh`, `bin/restore-db-lfs.sh` |
+| **Server backup** | Production/host cron with retention | `pg_dump -Fc` | `bin/server-backup.sh`, `bin/server-restore-drill.sh` |
+
+LFS fixtures ship in-repo for fast local setup. Server backups stay on the host (or off-site) and MUST NOT replace LFS for dev fixtures.
+
+## Infrastructure
+
+| Item | Value |
+| --- | --- |
+| Compose db service | `db` |
+| Container name | `electricity_db` |
+| Database | `electricity_prices` |
+| User | `electricity_user` |
+| LFS fixture | `data/db-backup/price-data.sql.gz` |
+| Host backup dir | `backups/postgres/` (gitignored) |
+
+## Tier 1: Git LFS fixture
+
+Full capture/restore details: [db-backup-lfs.md](db-backup-lfs.md).
+
+### Capture (after initial sync)
+
+```bash
+./bin/capture-db-lfs.sh
+# or poll until sync completes:
+./bin/capture-db-lfs.sh --wait 3600
+```
+
+### Restore locally (fresh volume)
+
+Destructive to the compose Postgres volume; resets schema then imports the LFS dump:
+
+```bash
+git lfs pull
+./bin/restore-db-lfs.sh --fresh-volume
+```
+
+Restore into a running db (resets `public` schema first):
+
+```bash
+./bin/restore-db-lfs.sh
+```
+
+Verify without changes:
+
+```bash
+./bin/restore-db-lfs.sh --verify-only
+```
+
+Post-restore smoke:
+
+```bash
+curl -s http://127.0.0.1:3000/health
+./bin/smoke-local.sh
+```
+
+## Tier 2: Server backup (production / Coolify host)
+
+### Automated backup
+
+```bash
+./bin/server-backup.sh
+```
+
+On a Coolify host where compose project names differ, use the container directly:
+
+```bash
+DB_CONTAINER=electricity_db USE_COMPOSE=0 BACKUP_DIR=/var/backups/nordpool/postgres ./bin/server-backup.sh
+```
+
+Output layout:
+
+```text
+backups/postgres/daily/electricity_prices-YYYYMMDD-HHMMSS.dump
+backups/postgres/weekly/   # Sunday copy of daily dump
+```
+
+Retention defaults: daily 7 days, weekly 4 weeks. Override with `RETENTION_DAYS` and `RETENTION_WEEKS`.
+
+### Cron recommendations
+
+| Job | Schedule | Command |
+| --- | --- | --- |
+| Daily dump | `0 3 * * *` | `cd /opt/nordpool && ./bin/server-backup.sh` |
+| Restore drill | `0 4 1 * *` | See below |
+
+Store copies **off the VPS** (object storage, second machine). A dump on the same disk as Postgres is not disaster recovery.
+
+### Restore drill (monthly, non-destructive)
+
+Creates `restore_drill_*`, restores latest dump, verifies row counts, drops drill DB. Production `electricity_prices` is not modified.
+
+```bash
+DUMP_FILE="$(ls -t backups/postgres/daily/*.dump | head -1)" ./bin/server-restore-drill.sh
+```
+
+On Coolify host:
+
+```bash
+DUMP_FILE=/var/backups/nordpool/postgres/daily/electricity_prices-20260615-030000.dump \
+  DB_CONTAINER=electricity_db USE_COMPOSE=0 ./bin/server-restore-drill.sh
+```
+
+### Pre-deploy backup (manual)
+
+Before risky migrations or compose changes on production:
+
+```bash
+BACKUP_DIR=/var/backups/nordpool/manual ./bin/server-backup.sh
+# or one-off:
+docker exec electricity_db pg_dump -U electricity_user -d electricity_prices -Fc --no-owner \
+  > /var/backups/nordpool/manual/pre-deploy-$(date +%Y%m%d).dump
+```
+
+Document the dump path in your deploy notes. Coolify does not run this automatically; operators run it before deploy.
+
+## Production restore (incident)
+
+Only with explicit approval. Test on drill DB first.
+
+1. Stop writers: `docker compose stop backend` (sync worker runs in backend)
+2. Choose dump file from `backups/postgres/daily/` or off-site copy
+3. Restore to production DB (product-specific; prefer `pg_restore` from `-Fc` dumps)
+4. Start services: `docker compose up -d`
+5. Run `./bin/smoke-local.sh` or hit `/health` and a price endpoint
+
+If restore fails mid-incident, keep the pre-restore dump and volume snapshot paths documented in deploy notes.
+
+## Restore drill checklist
+
+- [ ] Latest `pg_dump` file exists and is non-zero bytes
+- [ ] Dump age within your SLA (e.g. under 24h for daily cron)
+- [ ] `./bin/server-restore-drill.sh` succeeded this calendar month
+- [ ] LFS round-trip tested locally: `./bin/restore-db-lfs.sh --fresh-volume` then `--verify-only`
+- [ ] Off-site copy verified (download one file manually)
+- [ ] Pre-deploy backup noted before last production migration
+
+## Out of scope
+
+- Client IndexedDB export (Nordpool settings are server-backed; no flows client-export adoption yet)
+- Automatic LFS capture on sync completion (explicit human step)
+- Coolify-native backup UI configuration
+
+## Related
+
+- [db-backup-lfs.md](db-backup-lfs.md) — LFS capture and commit workflow
+- [data/db-backup/README.md](../../data/db-backup/README.md) — fixture directory
+- flows reference: `vendor/flows/components/backup-restore/`

--- a/docs/ops/db-backup-lfs.md
+++ b/docs/ops/db-backup-lfs.md
@@ -76,18 +76,26 @@ git lfs ls-files
 
 ## Restore locally
 
-**Into a fresh volume** (destroys existing DB data in the compose volume):
+Preferred (scripted, includes schema reset and verification):
 
 ```bash
-docker compose down
-docker volume rm lt-electricity-full-price-nordpool_postgres_data 2>/dev/null || true
-docker compose up -d db
-# wait for Postgres ready, then:
-gunzip -c data/db-backup/price-data.sql.gz | docker compose exec -T db psql -U electricity_user -d electricity_prices
-docker compose up -d
+git lfs pull
+./bin/restore-db-lfs.sh --fresh-volume
 ```
 
-Adjust volume name with `docker volume ls | grep postgres`.
+Restore into a running db without removing the volume:
+
+```bash
+./bin/restore-db-lfs.sh
+```
+
+Verify current database state:
+
+```bash
+./bin/restore-db-lfs.sh --verify-only
+```
+
+Server cron backups and production drills: [backup-restore.md](backup-restore.md).
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add `bin/restore-db-lfs.sh` for LFS fixture restore with schema reset, fresh-volume option, and verification queries
- Add `bin/server-backup.sh` (pg_dump -Fc, daily/weekly retention) and `bin/server-restore-drill.sh` (non-destructive monthly drill)
- Add unified runbook `docs/ops/backup-restore.md`; update `db-backup-lfs.md`, AGENTS.md, and `.gitignore`

Fixes #80

## Flows patterns adopted
| flows artifact | Nordpool adoption |
| --- | --- |
| `capture-db-lfs.example.sh` | Already present; updated restore pointer |
| `server-backup.example.sh` | `bin/server-backup.sh` (compose + docker exec) |
| `server-restore.example.sh` | `bin/server-restore-drill.sh` |
| `backup-restore.md.tpl` | `docs/ops/backup-restore.md` |

**Not adopted:** client-export, QR codec (out of scope; server-backed settings)

## Test plan
- [x] `bash -n` on all four bin scripts
- [ ] CI lint-and-unit
- [ ] Manual: `./bin/restore-db-lfs.sh --verify-only` with running db
- [ ] Manual: `./bin/server-backup.sh` + drill with dump file

## Local usage
```bash
# LFS restore (fresh volume)
git lfs pull && ./bin/restore-db-lfs.sh --fresh-volume

# Server backup + drill
./bin/server-backup.sh
DUMP_FILE=$(ls -t backups/postgres/daily/*.dump | head -1) ./bin/server-restore-drill.sh
```

Made with [Cursor](https://cursor.com)