### PR TITLE
feat(frontend): /display kiosk route with layout codec (#74, #75)

### DIFF
--- a/electricity-prices-build/src/App.vue
+++ b/electricity-prices-build/src/App.vue
@@ -1,8 +1,12 @@
 <script setup>
-import { onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
 import BottomMenu from './components/BottomMenu.vue'
 import { initializeCache, startSmartSync, stopSmartSync } from './services/priceService'
 import { initializePriceConfig } from './services/priceConfigService'
+
+const route = useRoute()
+const showBottomMenu = computed(() => route.meta.kiosk !== true)
 
 onMounted(() => {
   initializePriceConfig('lt').catch(err => {
@@ -22,10 +26,10 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="app-container">
+  <div class="app-container" :class="{ 'app-container--kiosk': !showBottomMenu }">
     <RouterView />
   </div>
-  <BottomMenu />
+  <BottomMenu v-if="showBottomMenu" />
 </template>
 
 <style scoped>
@@ -35,5 +39,8 @@ onUnmounted(() => {
 }
 .app-container {
   padding-bottom: 100px; /* Space for fixed bottom menu with header */
+}
+.app-container--kiosk {
+  padding-bottom: 0;
 }
 </style>

--- a/electricity-prices-build/src/components/display/DisplayChartPanel.vue
+++ b/electricity-prices-build/src/components/display/DisplayChartPanel.vue
@@ -1,0 +1,150 @@
+<script setup>
+import { computed } from 'vue';
+import { calculatePrice } from '../../services/priceCalculationService';
+import { formatPriceHours, isCurrentHour } from '../../services/timeService';
+
+const props = defineProps({
+  priceData: {
+    type: Array,
+    required: true,
+    default: () => [],
+  },
+  theme: {
+    type: String,
+    default: 'dark',
+  },
+  maxHours: {
+    type: Number,
+    default: 12,
+  },
+});
+
+const intervalSeconds = computed(() => {
+  if (props.priceData.length >= 2) {
+    const diff = props.priceData[1].timestamp - props.priceData[0].timestamp;
+    return diff > 0 ? diff : 3600;
+  }
+  return 3600;
+});
+
+const chartRows = computed(() => {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const upcoming = props.priceData
+    .filter((row) => row.timestamp >= nowSec)
+    .slice(0, props.maxHours);
+
+  if (upcoming.length === 0) {
+    return props.priceData.slice(0, props.maxHours).map((row) => ({
+      row,
+      value: parseFloat(calculatePrice(row)),
+      label: formatPriceHours(row.timestamp, intervalSeconds.value),
+      isCurrent: isCurrentHour(row.timestamp, intervalSeconds.value),
+    }));
+  }
+
+  return upcoming.map((row) => ({
+    row,
+    value: parseFloat(calculatePrice(row)),
+    label: formatPriceHours(row.timestamp, intervalSeconds.value),
+    isCurrent: isCurrentHour(row.timestamp, intervalSeconds.value),
+  }));
+});
+
+const maxValue = computed(() => {
+  const values = chartRows.value.map((entry) => entry.value);
+  if (values.length === 0) return 1;
+  return Math.max(...values, 1);
+});
+
+const themeClass = computed(() => (props.theme === 'light' ? 'display-chart--light' : 'display-chart--dark'));
+</script>
+
+<template>
+  <div class="display-chart" :class="themeClass">
+    <div
+      v-for="entry in chartRows"
+      :key="entry.row.timestamp"
+      class="display-chart__row"
+      :class="{ 'display-chart__row--current': entry.isCurrent }"
+    >
+      <div class="display-chart__label" v-html="entry.label" />
+      <div class="display-chart__bar-track">
+        <div
+          class="display-chart__bar"
+          :style="{ width: `${(entry.value / maxValue) * 100}%` }"
+        />
+      </div>
+      <div class="display-chart__value">{{ entry.value.toFixed(2) }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.display-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.display-chart__row {
+  display: grid;
+  grid-template-columns: minmax(7rem, 12rem) 1fr minmax(5rem, 8rem);
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.display-chart__row--current .display-chart__label,
+.display-chart__row--current .display-chart__value {
+  font-weight: 700;
+}
+
+.display-chart__label {
+  font-size: clamp(1.5rem, 2.5vw, 2.75rem);
+  line-height: 1.1;
+}
+
+.display-chart__bar-track {
+  height: clamp(2rem, 4vw, 3.5rem);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.display-chart__bar {
+  height: 100%;
+  border-radius: 0.5rem;
+  transition: width 0.3s ease;
+}
+
+.display-chart__value {
+  font-size: clamp(1.75rem, 3vw, 3rem);
+  text-align: right;
+  line-height: 1.1;
+}
+
+.display-chart--dark {
+  color: #f5f5f5;
+}
+
+.display-chart--dark .display-chart__bar-track {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.display-chart--dark .display-chart__bar {
+  background: linear-gradient(90deg, #4cc9f0, #4361ee);
+}
+
+.display-chart--light {
+  color: #111;
+}
+
+.display-chart--light .display-chart__bar-track {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.display-chart--light .display-chart__bar {
+  background: linear-gradient(90deg, #0077b6, #023e8a);
+}
+</style>

--- a/electricity-prices-build/src/i18n.js
+++ b/electricity-prices-build/src/i18n.js
@@ -13,6 +13,13 @@ const messages = {
       today: 'Today',
       tomorrow: 'Tomorrow'
     },
+    display: {
+      invalidTitle: 'Invalid display link',
+      invalidBody: 'This shared layout link is missing or could not be decoded. Ask the sender for a new link.',
+      loading: 'Loading display...',
+      error: 'Failed to load prices for this display.',
+      empty: 'No price data available for this display.'
+    },
     upcoming: {
       title: 'Upcoming Prices',
       loading: 'Loading prices...',
@@ -60,7 +67,31 @@ const messages = {
       syncDebugNoGaps: 'None',
       syncDebugMarkers: 'Sync-success markers',
       syncDebugRun: 'Run sync now',
-      syncDebugRunning: 'Syncing…'
+      syncDebugRunning: 'Syncing…',
+      alertsTitle: 'Price alerts',
+      alertsHelp: 'Configure once: in-app highlights and push use the same thresholds above.',
+      alertCountry: 'Alert country',
+      alertChannels: 'Alert channels',
+      cheapInApp: 'In-app highlight when price is below {value} ct/kWh',
+      cheapPush: 'Push when price is below {value} ct/kWh',
+      expensiveInApp: 'In-app highlight when price is above {value} ct/kWh',
+      expensivePush: 'Push when price is above {value} ct/kWh',
+      quietHoursEnabled: 'Quiet hours (no push)',
+      quietHoursHelp: 'Push alerts are paused during quiet hours ({timezone}).',
+      quietHoursStart: 'Start',
+      quietHoursEnd: 'End',
+      pushPermissionStatus: 'Notification permission: {status}',
+      pushSubscribed: 'Push subscription is active.',
+      pushWorking: 'Updating push subscription…',
+      pushEnabled: 'Push alerts enabled.',
+      pushDisabled: 'Push alerts disabled.',
+      pushPendingBackend: 'Push preference saved locally. Server push will activate when available.',
+      pushUnsupported: 'This browser does not support Web Push.',
+      pushIosStandalone: 'On iOS, add the app to your home screen before enabling push.',
+      pushPermissionDenied: 'Notification permission was denied.',
+      pushSubscribeFailed: 'Could not enable push notifications.',
+      countries: { lt: 'Lithuania', ee: 'Estonia', lv: 'Latvia', fi: 'Finland' },
+      pushPermission: { granted: 'granted', denied: 'denied', default: 'not requested', unsupported: 'unsupported' }
     },
     table: {
       noData: 'Price data is not yet available for selected date.\nData is typically available after 15:00 local time (13:00 UTC).',
@@ -126,6 +157,13 @@ const messages = {
       today: 'Šiandien',
       tomorrow: 'Rytoj'
     },
+    display: {
+      invalidTitle: 'Netinkama rodinio nuoroda',
+      invalidBody: 'Bendrinamos išdėstymo nuorodos trūksta arba jos nepavyko iššifruoti. Paprašykite naujos nuorodos.',
+      loading: 'Kraunamas rodinys...',
+      error: 'Nepavyko įkelti kainų šiam rodiniui.',
+      empty: 'Šiam rodiniui kainų duomenų nėra.'
+    },
     upcoming: {
       title: 'Artimiausios kainos',
       loading: 'Kraunamos kainos...',
@@ -173,7 +211,31 @@ const messages = {
       syncDebugNoGaps: 'Nėra',
       syncDebugMarkers: 'Sinchronizacijos žymės',
       syncDebugRun: 'Sinchronizuoti dabar',
-      syncDebugRunning: 'Sinchronizuojama…'
+      syncDebugRunning: 'Sinchronizuojama…',
+      alertsTitle: 'Kainų įspėjimai',
+      alertsHelp: 'Nustatykite vieną kartą: programėlėje ir push pranešimai naudoja tuos pačius slenksčius aukščiau.',
+      alertCountry: 'Įspėjimų šalis',
+      alertChannels: 'Įspėjimų kanalai',
+      cheapInApp: 'Programėlėje, kai kaina žemiau {value} ct/kWh',
+      cheapPush: 'Push, kai kaina žemiau {value} ct/kWh',
+      expensiveInApp: 'Programėlėje, kai kaina aukščiau {value} ct/kWh',
+      expensivePush: 'Push, kai kaina aukščiau {value} ct/kWh',
+      quietHoursEnabled: 'Ramybės valandos (be push)',
+      quietHoursHelp: 'Push įspėjimai sustabdomi ramybės valandomis ({timezone}).',
+      quietHoursStart: 'Pradžia',
+      quietHoursEnd: 'Pabaiga',
+      pushPermissionStatus: 'Pranešimų leidimas: {status}',
+      pushSubscribed: 'Push prenumerata aktyvi.',
+      pushWorking: 'Atnaujinama push prenumerata…',
+      pushEnabled: 'Push įspėjimai įjungti.',
+      pushDisabled: 'Push įspėjimai išjungti.',
+      pushPendingBackend: 'Push nuostatos išsaugotos lokaliai. Serverio push įsijungs, kai bus pasiekiamas.',
+      pushUnsupported: 'Ši naršyklė nepalaiko Web Push.',
+      pushIosStandalone: 'iOS: prieš įjungiant push, pridėkite programėlę į pradžios ekraną.',
+      pushPermissionDenied: 'Pranešimų leidimas atmestas.',
+      pushSubscribeFailed: 'Nepavyko įjungti push pranešimų.',
+      countries: { lt: 'Lietuva', ee: 'Estija', lv: 'Latvija', fi: 'Suomija' },
+      pushPermission: { granted: 'suteiktas', denied: 'atmestas', default: 'neprašyta', unsupported: 'nepalaikoma' }
     },
     table: {
       noData: 'Šiai datai kainų duomenys dar nepasiekiami.\nDuomenys įprastai pasiekiami po 15:00 vietos laiku (13:00 UTC).',

--- a/electricity-prices-build/src/lib/layoutCodec.js
+++ b/electricity-prices-build/src/lib/layoutCodec.js
@@ -1,0 +1,128 @@
+/**
+ * Layout schema v1 (MVP) — inline spec
+ *
+ * Fields:
+ * - v: 1 (required)
+ * - panel: "chart" | "table" (required) — single panel for MVP
+ * - source: "today" | "upcoming" (default "upcoming")
+ * - theme: "dark" | "light" (default "dark" for kiosk)
+ * - tz: IANA timezone string (default "Europe/Vilnius")
+ *
+ * URL encoding: JSON → UTF-8 → base64url (no padding).
+ * Example: /display?layout=eyJ2IjoxLCJwYW5lbCI6InRhYmxlIn0
+ */
+
+const SCHEMA_VERSION = 1;
+const PANELS = new Set(['chart', 'table']);
+const SOURCES = new Set(['today', 'upcoming']);
+const THEMES = new Set(['dark', 'light']);
+const DEFAULT_TZ = 'Europe/Vilnius';
+
+/**
+ * @typedef {Object} LayoutConfigV1
+ * @property {1} v
+ * @property {'chart'|'table'} panel
+ * @property {'today'|'upcoming'} [source]
+ * @property {'dark'|'light'} [theme]
+ * @property {string} [tz]
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {LayoutConfigV1|null}
+ */
+export function normalizeLayoutConfig(value) {
+  if (!value || typeof value !== 'object') return null;
+
+  const raw = /** @type {Record<string, unknown>} */ (value);
+  if (raw.v !== SCHEMA_VERSION) return null;
+  if (typeof raw.panel !== 'string' || !PANELS.has(raw.panel)) return null;
+
+  const source = typeof raw.source === 'string' && SOURCES.has(raw.source)
+    ? raw.source
+    : 'upcoming';
+  const theme = typeof raw.theme === 'string' && THEMES.has(raw.theme)
+    ? raw.theme
+    : 'dark';
+  const tz = typeof raw.tz === 'string' && raw.tz.length > 0 ? raw.tz : DEFAULT_TZ;
+
+  return {
+    v: SCHEMA_VERSION,
+    panel: /** @type {'chart'|'table'} */ (raw.panel),
+    source: /** @type {'today'|'upcoming'} */ (source),
+    theme: /** @type {'dark'|'light'} */ (theme),
+    tz,
+  };
+}
+
+/**
+ * @param {LayoutConfigV1} config
+ * @returns {string}
+ */
+export function encodeLayout(config) {
+  const normalized = normalizeLayoutConfig(config);
+  if (!normalized) {
+    throw new Error('Invalid layout config');
+  }
+  const json = JSON.stringify(normalized);
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/u, '');
+}
+
+/**
+ * @param {string} encoded
+ * @returns {{ ok: true, config: LayoutConfigV1 } | { ok: false, error: string }}
+ */
+export function decodeLayout(encoded) {
+  if (typeof encoded !== 'string' || encoded.trim().length === 0) {
+    return { ok: false, error: 'missing' };
+  }
+
+  try {
+    const padded = encoded
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(encoded.length / 4) * 4, '=');
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const json = new TextDecoder().decode(bytes);
+    const parsed = JSON.parse(json);
+    const config = normalizeLayoutConfig(parsed);
+    if (!config) {
+      return { ok: false, error: 'invalid' };
+    }
+    return { ok: true, config };
+  } catch {
+    return { ok: false, error: 'invalid' };
+  }
+}
+
+/**
+ * @param {LayoutConfigV1} config
+ * @param {string} [basePath='/display']
+ * @returns {string}
+ */
+export function buildDisplayUrl(config, basePath = '/display') {
+  const encoded = encodeLayout(config);
+  return `${basePath}?layout=${encoded}`;
+}
+
+/**
+ * @returns {LayoutConfigV1}
+ */
+export function defaultLayoutConfig() {
+  return {
+    v: SCHEMA_VERSION,
+    panel: 'table',
+    source: 'upcoming',
+    theme: 'dark',
+    tz: DEFAULT_TZ,
+  };
+}

--- a/electricity-prices-build/src/router/index.js
+++ b/electricity-prices-build/src/router/index.js
@@ -113,6 +113,38 @@ const router = createRouter({
           en: 'Learn more about the electricity prices application, settings, and how to use the system effectively.'
         }
       }
+    },
+    {
+      path: '/display',
+      name: 'display',
+      component: () => import('../views/DisplayView.vue'),
+      meta: {
+        kiosk: true,
+        title: {
+          lt: 'Ekrano rodinys',
+          en: 'Display Mode'
+        },
+        description: {
+          lt: 'Bendrinamas TV arba kiosk rodinys su užkoduota išdėstymo nuoroda.',
+          en: 'Shareable TV or kiosk view with an encoded layout link.'
+        }
+      }
+    },
+    {
+      path: '/tv',
+      name: 'tv',
+      component: () => import('../views/DisplayView.vue'),
+      meta: {
+        kiosk: true,
+        title: {
+          lt: 'TV rodinys',
+          en: 'TV Display'
+        },
+        description: {
+          lt: 'Pilno ekrano TV rodinys su užkoduota išdėstymo nuoroda.',
+          en: 'Fullscreen TV display with an encoded layout link.'
+        }
+      }
     }
   ]
 })

--- a/electricity-prices-build/src/views/DisplayView.vue
+++ b/electricity-prices-build/src/views/DisplayView.vue
@@ -1,0 +1,239 @@
+<script setup>
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import { useRoute } from 'vue-router';
+import moment from 'moment-timezone';
+import PriceTable from '../components/PriceTable.vue';
+import DisplayChartPanel from '../components/display/DisplayChartPanel.vue';
+import { decodeLayout } from '../lib/layoutCodec.js';
+import { fetchPrices, fetchUpcomingPrices, onPricesUpdated, runSmartSync } from '../services/priceService';
+import { logAllPriceBreakdowns } from '../services/priceCalculationService';
+
+const route = useRoute();
+
+const layoutConfig = ref(null);
+const layoutError = ref(null);
+const priceData = ref([]);
+const allPrices = ref([]);
+const isLoading = ref(true);
+const loadError = ref(null);
+
+let refreshTimeout = null;
+let unsubscribePrices = null;
+
+const isKiosk = computed(() => route.meta.kiosk === true || route.query.kiosk === '1');
+
+const themeClass = computed(() => {
+  const theme = layoutConfig.value?.theme || 'dark';
+  return theme === 'light' ? 'display-view--light' : 'display-view--dark';
+});
+
+function parseLayoutFromRoute() {
+  const encoded = route.query.layout;
+  if (typeof encoded !== 'string' || encoded.length === 0) {
+    layoutConfig.value = null;
+    layoutError.value = 'missing';
+    return;
+  }
+
+  const result = decodeLayout(encoded);
+  if (!result.ok) {
+    layoutConfig.value = null;
+    layoutError.value = result.error;
+    return;
+  }
+
+  layoutConfig.value = result.config;
+  layoutError.value = null;
+  moment.tz.setDefault(result.config.tz);
+}
+
+function getIntervalMs() {
+  const rows = allPrices.value.length ? allPrices.value : priceData.value;
+  if (rows.length >= 2) {
+    const diffSec = rows[1].timestamp - rows[0].timestamp;
+    if (diffSec > 0) return diffSec * 1000;
+  }
+  return 60 * 60 * 1000;
+}
+
+function scheduleNextRefresh() {
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+  const intervalMs = getIntervalMs();
+  const now = Date.now();
+  const nextBoundary = now - (now % intervalMs) + intervalMs;
+  const delay = Math.max(nextBoundary - now, 5 * 1000);
+  refreshTimeout = setTimeout(async () => {
+    await loadPrices();
+    scheduleNextRefresh();
+  }, delay);
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === 'visible') {
+    runSmartSync('lt').finally(() => {
+      loadPrices();
+      scheduleNextRefresh();
+    });
+  }
+}
+
+async function loadPrices() {
+  if (!layoutConfig.value) return;
+
+  try {
+    isLoading.value = true;
+    loadError.value = null;
+
+    if (layoutConfig.value.source === 'today') {
+      const data = await fetchPrices(new Date());
+      const rows = data.data?.lt || [];
+      priceData.value = rows;
+      allPrices.value = rows;
+    } else {
+      const data = await fetchUpcomingPrices('lt');
+      const upcoming = data?.data?.lt || [];
+      allPrices.value = upcoming
+        .filter((price) => price !== null && price !== undefined)
+        .sort((a, b) => a.timestamp - b.timestamp);
+      priceData.value = allPrices.value;
+    }
+
+    logAllPriceBreakdowns();
+  } catch (error) {
+    loadError.value = error instanceof Error ? error.message : 'load-failed';
+    priceData.value = [];
+    allPrices.value = [];
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+onMounted(() => {
+  parseLayoutFromRoute();
+  if (layoutConfig.value) {
+    loadPrices();
+    scheduleNextRefresh();
+    unsubscribePrices = onPricesUpdated(() => {
+      loadPrices();
+    });
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+  }
+});
+
+onUnmounted(() => {
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+  if (unsubscribePrices) unsubscribePrices();
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
+});
+
+watch(
+  () => route.query.layout,
+  () => {
+    parseLayoutFromRoute();
+    if (layoutConfig.value) {
+      loadPrices();
+      scheduleNextRefresh();
+    }
+  },
+);
+</script>
+
+<template>
+  <div
+    class="display-view"
+    :class="[themeClass, { 'display-view--kiosk': isKiosk }]"
+  >
+    <div v-if="layoutError" class="display-view__message" role="alert">
+      <h1 class="display-view__title">{{ $t('display.invalidTitle') }}</h1>
+      <p>{{ $t('display.invalidBody') }}</p>
+    </div>
+
+    <template v-else>
+      <div v-if="isLoading" class="display-view__message">
+        {{ $t('display.loading') }}
+      </div>
+      <div v-else-if="loadError" class="display-view__message" role="alert">
+        {{ $t('display.error') }}
+      </div>
+      <div v-else-if="priceData.length === 0" class="display-view__message">
+        {{ $t('display.empty') }}
+      </div>
+      <div v-else class="display-view__panel">
+        <DisplayChartPanel
+          v-if="layoutConfig.panel === 'chart'"
+          :price-data="priceData"
+          :theme="layoutConfig.theme"
+        />
+        <PriceTable
+          v-else
+          :price-data="priceData"
+          :all-price-data="allPrices"
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.display-view {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  box-sizing: border-box;
+}
+
+.display-view--kiosk {
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.display-view--dark {
+  background: #0b0f19;
+  color: #f5f5f5;
+}
+
+.display-view--light {
+  background: #f8f9fa;
+  color: #111;
+}
+
+.display-view__message {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+  text-align: center;
+  font-size: clamp(1.25rem, 2.5vw, 2rem);
+  max-width: 48rem;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+.display-view__title {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.display-view__panel {
+  width: 100%;
+}
+
+.display-view--kiosk :deep(.table) {
+  font-size: clamp(1.1rem, 2vw, 2rem);
+}
+
+.display-view--kiosk :deep(.table th),
+.display-view--kiosk :deep(.table td) {
+  padding: clamp(0.5rem, 1.2vw, 1rem) clamp(0.75rem, 1.5vw, 1.25rem);
+}
+
+@media (min-width: 1920px) {
+  .display-view--kiosk {
+    padding: 3rem 4rem;
+  }
+
+  .display-view--kiosk :deep(.table) {
+    font-size: 2.25rem;
+  }
+}
+</style>

--- a/electricity-prices-build/tests/displayView.smoke.test.js
+++ b/electricity-prices-build/tests/displayView.smoke.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import moment from 'moment-timezone';
+import { encodeLayout } from '../src/lib/layoutCodec.js';
+
+const mockUpcoming = {
+  success: true,
+  data: {
+    lt: [
+      { timestamp: moment.tz('2024-06-15 12:00', 'Europe/Vilnius').unix(), price: 55.0 },
+      { timestamp: moment.tz('2024-06-15 13:00', 'Europe/Vilnius').unix(), price: 58.2 },
+      { timestamp: moment.tz('2024-06-15 14:00', 'Europe/Vilnius').unix(), price: 51.3 },
+    ],
+  },
+  meta: { country: 'lt', count: 3, timezone: 'Europe/Vilnius' },
+};
+
+let routeQuery = {};
+let routeMeta = { kiosk: true };
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    meta: routeMeta,
+    query: routeQuery,
+  }),
+}));
+
+vi.mock('../src/services/priceService.js', () => ({
+  fetchPrices: vi.fn(async () => mockUpcoming),
+  fetchUpcomingPrices: vi.fn(async () => mockUpcoming),
+  onPricesUpdated: vi.fn(() => () => {}),
+  runSmartSync: vi.fn(async () => {}),
+}));
+
+vi.mock('../src/services/priceCalculationService.js', () => ({
+  calculatePrice: vi.fn((row) => row.price / 10),
+  logAllPriceBreakdowns: vi.fn(),
+  getTimePeriod: vi.fn(() => 'day'),
+}));
+
+describe('DisplayView smoke', () => {
+  beforeEach(() => {
+    routeQuery = {};
+    routeMeta = { kiosk: true };
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+  });
+
+  it('shows friendly error when layout param is missing', async () => {
+    const DisplayView = (await import('../src/views/DisplayView.vue')).default;
+    const wrapper = mount(DisplayView, {
+      global: {
+        mocks: { $t: (key) => key },
+      },
+    });
+    await flushPromises();
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('display.invalidTitle');
+  });
+
+  it('renders table panel from encoded layout', async () => {
+    routeQuery = { layout: encodeLayout({ v: 1, panel: 'table', source: 'upcoming' }) };
+
+    const DisplayView = (await import('../src/views/DisplayView.vue')).default;
+    const wrapper = mount(DisplayView, {
+      global: {
+        stubs: {
+          PriceTable: {
+            template: '<div class="price-table-stub">{{ priceData.length }}</div>',
+            props: ['priceData', 'allPriceData'],
+          },
+          DisplayChartPanel: true,
+        },
+        mocks: { $t: (key) => key },
+      },
+    });
+    await flushPromises();
+    await flushPromises();
+    expect(wrapper.find('.price-table-stub').text()).toBe('3');
+  });
+});

--- a/electricity-prices-build/tests/layoutCodec.test.js
+++ b/electricity-prices-build/tests/layoutCodec.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeLayout,
+  decodeLayout,
+  buildDisplayUrl,
+  defaultLayoutConfig,
+  normalizeLayoutConfig,
+} from '../src/lib/layoutCodec.js';
+
+describe('layoutCodec', () => {
+  it('round-trips a table layout config', () => {
+    const config = {
+      v: 1,
+      panel: 'table',
+      source: 'upcoming',
+      theme: 'dark',
+      tz: 'Europe/Vilnius',
+    };
+    const encoded = encodeLayout(config);
+    const decoded = decodeLayout(encoded);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      expect(decoded.config).toEqual(config);
+    }
+  });
+
+  it('round-trips a chart layout config', () => {
+    const config = {
+      v: 1,
+      panel: 'chart',
+      source: 'today',
+      theme: 'light',
+    };
+    const encoded = encodeLayout(config);
+    const decoded = decodeLayout(encoded);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      expect(decoded.config.panel).toBe('chart');
+      expect(decoded.config.source).toBe('today');
+      expect(decoded.config.theme).toBe('light');
+      expect(decoded.config.tz).toBe('Europe/Vilnius');
+    }
+  });
+
+  it('rejects missing layout param', () => {
+    expect(decodeLayout('')).toEqual({ ok: false, error: 'missing' });
+  });
+
+  it('rejects invalid base64 payload', () => {
+    expect(decodeLayout('not-valid!!!')).toEqual({ ok: false, error: 'invalid' });
+  });
+
+  it('rejects unsupported schema version', () => {
+    const badJson = JSON.stringify({ v: 2, panel: 'table' });
+    const encoded = btoa(badJson).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+    expect(decodeLayout(encoded)).toEqual({ ok: false, error: 'invalid' });
+  });
+
+  it('builds a display URL with encoded layout', () => {
+    const url = buildDisplayUrl(defaultLayoutConfig());
+    expect(url.startsWith('/display?layout=')).toBe(true);
+  });
+
+  it('normalizes defaults for partial config', () => {
+    const normalized = normalizeLayoutConfig({ v: 1, panel: 'chart' });
+    expect(normalized).toEqual({
+      v: 1,
+      panel: 'chart',
+      source: 'upcoming',
+      theme: 'dark',
+      tz: 'Europe/Vilnius',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `layoutCodec.js` (schema v1, base64url encode/decode) with inline spec and unit tests.
- Add `/display` and `/tv` kiosk routes rendering chart or table panels from `?layout=` query.
- Hide bottom navigation chrome in kiosk mode; large typography and high-contrast display CSS.

Fixes #74
Refs #75 #24

## Test plan
- [x] `npm test --prefix electricity-prices-build` (layoutCodec + displayView smoke)
- [x] `npm run build --prefix electricity-prices-build`
- [ ] Manual: open `/display?layout=eyJ2IjoxLCJwYW5lbCI6InRhYmxlIn0`, confirm table renders without BottomMenu