### PR TITLE
feat(pwa): complete layout share links (#75)

### DIFF
--- a/electricity-prices-build/public/site.webmanifest
+++ b/electricity-prices-build/public/site.webmanifest
@@ -19,5 +19,9 @@
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
-  "display": "standalone"
+  "display": "standalone",
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  },
+  "handle_links": "preferred"
 }

--- a/electricity-prices-build/src/i18n.js
+++ b/electricity-prices-build/src/i18n.js
@@ -18,7 +18,10 @@ const messages = {
       invalidBody: 'This shared layout link is missing or could not be decoded. Ask the sender for a new link.',
       loading: 'Loading display...',
       error: 'Failed to load prices for this display.',
-      empty: 'No price data available for this display.'
+      empty: 'No price data available for this display.',
+      copyLink: 'Copy share link',
+      copied: 'Copied!',
+      copyFailed: 'Could not copy link'
     },
     upcoming: {
       title: 'Upcoming Prices',
@@ -162,7 +165,10 @@ const messages = {
       invalidBody: 'Bendrinamos išdėstymo nuorodos trūksta arba jos nepavyko iššifruoti. Paprašykite naujos nuorodos.',
       loading: 'Kraunamas rodinys...',
       error: 'Nepavyko įkelti kainų šiam rodiniui.',
-      empty: 'Šiam rodiniui kainų duomenų nėra.'
+      empty: 'Šiam rodiniui kainų duomenų nėra.',
+      copyLink: 'Kopijuoti nuorodą',
+      copied: 'Nukopijuota!',
+      copyFailed: 'Nepavyko nukopijuoti nuorodos'
     },
     upcoming: {
       title: 'Artimiausios kainos',

--- a/electricity-prices-build/src/lib/layoutCodec.js
+++ b/electricity-prices-build/src/lib/layoutCodec.js
@@ -126,3 +126,50 @@ export function defaultLayoutConfig() {
     tz: DEFAULT_TZ,
   };
 }
+
+/**
+ * @param {LayoutConfigV1} config
+ * @returns {string}
+ */
+export function exportLayoutJson(config) {
+  const normalized = normalizeLayoutConfig(config);
+  if (!normalized) {
+    throw new Error('Invalid layout config');
+  }
+  return JSON.stringify(normalized, null, 2);
+}
+
+/**
+ * @param {string} jsonString
+ * @returns {{ ok: true, config: LayoutConfigV1 } | { ok: false, error: string }}
+ */
+export function importLayoutJson(jsonString) {
+  if (typeof jsonString !== 'string' || jsonString.trim().length === 0) {
+    return { ok: false, error: 'missing' };
+  }
+
+  try {
+    const parsed = JSON.parse(jsonString);
+    const config = normalizeLayoutConfig(parsed);
+    if (!config) {
+      return { ok: false, error: 'invalid' };
+    }
+    return { ok: true, config };
+  } catch {
+    return { ok: false, error: 'invalid' };
+  }
+}
+
+/**
+ * Build an absolute share URL for the current origin.
+ * @param {LayoutConfigV1} config
+ * @param {string} [basePath='/display']
+ * @returns {string}
+ */
+export function buildShareUrl(config, basePath = '/display') {
+  const relative = buildDisplayUrl(config, basePath);
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return `${window.location.origin}${relative}`;
+  }
+  return relative;
+}

--- a/electricity-prices-build/src/views/DisplayView.vue
+++ b/electricity-prices-build/src/views/DisplayView.vue
@@ -4,7 +4,7 @@ import { useRoute } from 'vue-router';
 import moment from 'moment-timezone';
 import PriceTable from '../components/PriceTable.vue';
 import DisplayChartPanel from '../components/display/DisplayChartPanel.vue';
-import { decodeLayout } from '../lib/layoutCodec.js';
+import { decodeLayout, buildShareUrl } from '../lib/layoutCodec.js';
 import { fetchPrices, fetchUpcomingPrices, onPricesUpdated, runSmartSync } from '../services/priceService';
 import { logAllPriceBreakdowns } from '../services/priceCalculationService';
 
@@ -16,8 +16,10 @@ const priceData = ref([]);
 const allPrices = ref([]);
 const isLoading = ref(true);
 const loadError = ref(null);
+const copyStatus = ref(null);
 
 let refreshTimeout = null;
+let copyStatusTimeout = null;
 let unsubscribePrices = null;
 
 const isKiosk = computed(() => route.meta.kiosk === true || route.query.kiosk === '1');
@@ -120,8 +122,26 @@ onMounted(() => {
   }
 });
 
+async function copyShareLink() {
+  if (!layoutConfig.value) return;
+
+  const url = buildShareUrl(layoutConfig.value, route.path.startsWith('/tv') ? '/tv' : '/display');
+  try {
+    await navigator.clipboard.writeText(url);
+    copyStatus.value = 'copied';
+  } catch {
+    copyStatus.value = 'failed';
+  }
+
+  if (copyStatusTimeout) clearTimeout(copyStatusTimeout);
+  copyStatusTimeout = setTimeout(() => {
+    copyStatus.value = null;
+  }, 2500);
+}
+
 onUnmounted(() => {
   if (refreshTimeout) clearTimeout(refreshTimeout);
+  if (copyStatusTimeout) clearTimeout(copyStatusTimeout);
   if (unsubscribePrices) unsubscribePrices();
   document.removeEventListener('visibilitychange', handleVisibilityChange);
 });
@@ -149,6 +169,23 @@ watch(
     </div>
 
     <template v-else>
+      <div class="display-view__toolbar">
+        <button
+          type="button"
+          class="display-view__copy"
+          :aria-label="$t('display.copyLink')"
+          @click="copyShareLink"
+        >
+          {{ copyStatus === 'copied' ? $t('display.copied') : $t('display.copyLink') }}
+        </button>
+        <span
+          v-if="copyStatus === 'failed'"
+          class="display-view__copy-error"
+          role="status"
+        >
+          {{ $t('display.copyFailed') }}
+        </span>
+      </div>
       <div v-if="isLoading" class="display-view__message">
         {{ $t('display.loading') }}
       </div>
@@ -212,6 +249,35 @@ watch(
 .display-view__title {
   font-size: clamp(2rem, 4vw, 3.5rem);
   margin-bottom: 1rem;
+}
+
+.display-view__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.display-view__copy {
+  font-size: clamp(0.875rem, 1.5vw, 1.125rem);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.85;
+}
+
+.display-view__copy:hover,
+.display-view__copy:focus-visible {
+  opacity: 1;
+}
+
+.display-view__copy-error {
+  font-size: 0.875rem;
+  color: #f87171;
 }
 
 .display-view__panel {

--- a/electricity-prices-build/tests/layoutCodec.test.js
+++ b/electricity-prices-build/tests/layoutCodec.test.js
@@ -5,6 +5,8 @@ import {
   buildDisplayUrl,
   defaultLayoutConfig,
   normalizeLayoutConfig,
+  exportLayoutJson,
+  importLayoutJson,
 } from '../src/lib/layoutCodec.js';
 
 describe('layoutCodec', () => {
@@ -70,5 +72,21 @@ describe('layoutCodec', () => {
       theme: 'dark',
       tz: 'Europe/Vilnius',
     });
+  });
+
+  it('exports and imports layout JSON', () => {
+    const config = defaultLayoutConfig();
+    const json = exportLayoutJson(config);
+    const imported = importLayoutJson(json);
+    expect(imported.ok).toBe(true);
+    if (imported.ok) {
+      expect(imported.config).toEqual(config);
+    }
+  });
+
+  it('rejects invalid layout JSON import', () => {
+    expect(importLayoutJson('')).toEqual({ ok: false, error: 'missing' });
+    expect(importLayoutJson('{not json')).toEqual({ ok: false, error: 'invalid' });
+    expect(importLayoutJson('{"v":2,"panel":"table"}')).toEqual({ ok: false, error: 'invalid' });
   });
 });


### PR DESCRIPTION
## Summary
- Add `exportLayoutJson` / `importLayoutJson` helpers for offline layout sharing.
- Configure PWA `launch_handler` and `handle_links` so shared `/display` URLs open in the installed app.
- Add copy-share-link control on kiosk display views with LT/EN copy.

Fixes #75

## Test plan
- [x] `npm test --prefix electricity-prices-build`
- [ ] Manual: open `/display?layout=…`, click Copy share link, paste in new tab


Made with [Cursor](https://cursor.com)