### PR TITLE
feat(backend): admin push management API (#15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ ELERING_API_URL=https://dashboard.elering.ee/api/nps/price
 DATABASE_URL=postgresql://electricity_user:CHANGE_ME@db:5432/electricity_prices
 ADMIN_API_TOKEN=CHANGE_ME
 
+# Web Push (optional — generate with: npx web-push generate-vapid-keys)
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:ops@example.com
+
 # Database (development only — use platform secrets in production)
 POSTGRES_DB=electricity_prices
 POSTGRES_USER=electricity_user

--- a/COOLIFY_DEPLOYMENT.md
+++ b/COOLIFY_DEPLOYMENT.md
@@ -112,6 +112,19 @@ FRONTEND_PORT=8080
 NODE_ENV=production
 ELERING_API_URL=https://dashboard.elering.ee/api/nps/price
 VITE_API_BASE_URL=/api/v1
+ADMIN_API_TOKEN=your_admin_token_here
+```
+
+**Web Push (optional)** — required only for push subscribe/broadcast admin APIs:
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+```env
+VAPID_PUBLIC_KEY=your_vapid_public_key
+VAPID_PRIVATE_KEY=your_vapid_private_key
+VAPID_SUBJECT=mailto:ops@yourdomain.com
 ```
 
 **Important Notes**:

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,8 @@
         "helmet": "^8.2.0",
         "moment-timezone": "^0.6.2",
         "node-cron": "^4.2.1",
-        "pg": "^8.21.0"
+        "pg": "^8.21.0",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "js-yaml": "^4.2.0",
@@ -94,6 +95,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -134,6 +147,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -184,6 +203,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -376,6 +401,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -756,6 +790,15 @@
         "url": "https://github.com/sponsors/EvanHahn"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -902,6 +945,27 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -953,6 +1017,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -967,6 +1037,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/moment": {
@@ -1352,6 +1431,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1674,6 +1773,47 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "helmet": "^8.2.0",
     "moment-timezone": "^0.6.2",
     "node-cron": "^4.2.1",
-    "pg": "^8.21.0"
+    "pg": "^8.21.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "js-yaml": "^4.2.0",

--- a/backend/src/push/adminRouter.js
+++ b/backend/src/push/adminRouter.js
@@ -1,0 +1,159 @@
+import express from 'express';
+import { requireVapid } from './vapid.js';
+import { sendPushToSubscription } from './delivery.js';
+
+export function createPushAdminRouter({ pool }) {
+  const router = express.Router();
+
+  router.get('/stats', async (_req, res) => {
+    try {
+      const [{ rows: subRows }, { rows: failRows }, { rows: sentRows }] = await Promise.all([
+        pool.query(
+          `SELECT
+             COUNT(*) FILTER (WHERE active) AS active_count,
+             COUNT(*) AS total_count
+           FROM push_subscriptions`,
+        ),
+        pool.query(
+          `SELECT COUNT(*) AS failure_count
+           FROM push_delivery_failures
+           WHERE failed_at > NOW() - INTERVAL '24 hours'`,
+        ),
+        pool.query(
+          `SELECT COUNT(*) AS sent_count
+           FROM push_sent_log
+           WHERE sent_at > NOW() - INTERVAL '24 hours'`,
+        ),
+      ]);
+
+      res.json({
+        success: true,
+        data: {
+          subscriptions: {
+            active: Number(subRows[0]?.active_count || 0),
+            total: Number(subRows[0]?.total_count || 0),
+          },
+          last24h: {
+            sent: Number(sentRows[0]?.sent_count || 0),
+            failures: Number(failRows[0]?.failure_count || 0),
+          },
+          configured: true,
+        },
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: 'Failed to load push stats',
+        details: error.message,
+      });
+    }
+  });
+
+  router.get('/deliveries', async (req, res) => {
+    const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
+
+    try {
+      const [{ rows: sent }, { rows: failures }] = await Promise.all([
+        pool.query(
+          `SELECT s.id, s.sub_id, s.dedupe_key, s.sent_at, sub.endpoint
+           FROM push_sent_log s
+           JOIN push_subscriptions sub ON sub.id = s.sub_id
+           ORDER BY s.sent_at DESC
+           LIMIT $1`,
+          [limit],
+        ),
+        pool.query(
+          `SELECT f.id, f.sub_id, f.dedupe_key, f.error_message, f.failed_at, sub.endpoint
+           FROM push_delivery_failures f
+           JOIN push_subscriptions sub ON sub.id = f.sub_id
+           ORDER BY f.failed_at DESC
+           LIMIT $1`,
+          [limit],
+        ),
+      ]);
+
+      res.json({
+        success: true,
+        data: { sent, failures },
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: 'Failed to load deliveries',
+        details: error.message,
+      });
+    }
+  });
+
+  router.post('/test', async (req, res) => {
+    try {
+      requireVapid();
+    } catch {
+      return res.status(503).json({ success: false, error: 'not_configured' });
+    }
+
+    const { subscriptionId, title, body, url } = req.body || {};
+    if (!subscriptionId) {
+      return res.status(400).json({ success: false, error: 'missing_subscription_id' });
+    }
+
+    const { rows } = await pool.query(
+      `SELECT id, endpoint, p256dh, auth FROM push_subscriptions
+       WHERE id = $1 AND active = true`,
+      [subscriptionId],
+    );
+
+    if (!rows.length) {
+      return res.status(404).json({ success: false, error: 'not_found' });
+    }
+
+    const result = await sendPushToSubscription(
+      pool,
+      rows[0],
+      { title, body, url },
+      `admin-test:${Date.now()}`,
+    );
+
+    if (!result.ok) {
+      return res.status(502).json({ success: false, error: result.error });
+    }
+
+    res.json({ success: true });
+  });
+
+  router.post('/broadcast', async (req, res) => {
+    try {
+      requireVapid();
+    } catch {
+      return res.status(503).json({ success: false, error: 'not_configured' });
+    }
+
+    const { title, body, url, activeOnly = true } = req.body || {};
+    if (!title || !body) {
+      return res.status(400).json({ success: false, error: 'missing_message' });
+    }
+
+    const { rows } = await pool.query(
+      `SELECT id, endpoint, p256dh, auth FROM push_subscriptions
+       WHERE active = $1 OR $1 = false`,
+      [activeOnly !== false],
+    );
+
+    const dedupeKey = `broadcast:${Date.now()}`;
+    let sent = 0;
+    let failed = 0;
+
+    for (const row of rows) {
+      const result = await sendPushToSubscription(pool, row, { title, body, url }, dedupeKey);
+      if (result.ok) sent += 1;
+      else failed += 1;
+    }
+
+    res.json({
+      success: true,
+      data: { targeted: rows.length, sent, failed },
+    });
+  });
+
+  return router;
+}

--- a/backend/src/push/delivery.js
+++ b/backend/src/push/delivery.js
@@ -1,0 +1,60 @@
+import webpush from 'web-push';
+import { requireVapid } from './vapid.js';
+
+const DEFAULT_TITLE = 'Elektros kaina LT';
+
+/**
+ * @param {import('pg').Pool} pool
+ * @param {{ id: string, endpoint: string, p256dh: string, auth: string }} subscription
+ * @param {{ title?: string, body?: string, url?: string }} message
+ * @param {string} [dedupeKey]
+ */
+export async function sendPushToSubscription(pool, subscription, message, dedupeKey = null) {
+  requireVapid();
+
+  const payload = JSON.stringify({
+    title: message.title || DEFAULT_TITLE,
+    body: message.body || '',
+    url: message.url || '/',
+  });
+
+  const pushSubscription = {
+    endpoint: subscription.endpoint,
+    keys: { p256dh: subscription.p256dh, auth: subscription.auth },
+  };
+
+  try {
+    await webpush.sendNotification(pushSubscription, payload);
+
+    if (dedupeKey) {
+      await pool.query(
+        `INSERT INTO push_sent_log (sub_id, dedupe_key)
+         VALUES ($1, $2)
+         ON CONFLICT (sub_id, dedupe_key) DO NOTHING`,
+        [subscription.id, dedupeKey],
+      );
+    }
+
+    await pool.query(
+      `UPDATE push_subscriptions SET last_error = NULL, updated_at = NOW() WHERE id = $1`,
+      [subscription.id],
+    );
+
+    return { ok: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    await pool.query(
+      `UPDATE push_subscriptions SET last_error = $2, updated_at = NOW() WHERE id = $1`,
+      [subscription.id, errorMessage],
+    );
+
+    await pool.query(
+      `INSERT INTO push_delivery_failures (sub_id, dedupe_key, error_message, payload_json)
+       VALUES ($1, $2, $3, $4::jsonb)`,
+      [subscription.id, dedupeKey, errorMessage, payload],
+    );
+
+    return { ok: false, error: errorMessage };
+  }
+}

--- a/backend/src/push/router.js
+++ b/backend/src/push/router.js
@@ -1,0 +1,112 @@
+import express from 'express';
+import crypto from 'node:crypto';
+import { requireVapid, isPushConfigured } from './vapid.js';
+import { createManageToken, hashManageToken } from './tokens.js';
+import { sendPushToSubscription } from './delivery.js';
+
+export function createPushRouter({ pool }) {
+  const router = express.Router();
+
+  router.get('/vapid-public', (_req, res) => {
+    try {
+      const { publicKey } = requireVapid();
+      res.json({ success: true, publicKey });
+    } catch {
+      res.status(503).json({ success: false, error: 'not_configured' });
+    }
+  });
+
+  router.get('/status', (_req, res) => {
+    res.json({
+      success: true,
+      configured: isPushConfigured(),
+    });
+  });
+
+  router.post('/subscribe', async (req, res) => {
+    try {
+      requireVapid();
+    } catch {
+      return res.status(503).json({ success: false, error: 'not_configured' });
+    }
+
+    const sub = req.body?.pushSubscription;
+    if (!sub?.endpoint || !sub?.keys?.p256dh || !sub?.keys?.auth) {
+      return res.status(400).json({ success: false, error: 'invalid_subscription' });
+    }
+
+    const id = crypto.randomUUID();
+    const manageToken = createManageToken();
+    const payloadJson = JSON.stringify(req.body?.productPayload || {});
+
+    await pool.query(
+      `INSERT INTO push_subscriptions
+         (id, endpoint, p256dh, auth, payload_json, manage_token_hash, created_at, updated_at, active)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6, NOW(), NOW(), true)
+       ON CONFLICT (endpoint) DO UPDATE SET
+         p256dh = EXCLUDED.p256dh,
+         auth = EXCLUDED.auth,
+         payload_json = EXCLUDED.payload_json,
+         manage_token_hash = EXCLUDED.manage_token_hash,
+         updated_at = NOW(),
+         active = true
+       RETURNING id`,
+      [id, sub.endpoint, sub.keys.p256dh, sub.keys.auth, payloadJson, hashManageToken(manageToken)],
+    );
+
+    res.status(201).json({ success: true, id, manageToken });
+  });
+
+  router.delete('/subscribe', async (req, res) => {
+    const { id, manageToken } = req.body || {};
+    if (!id || !manageToken) {
+      return res.status(400).json({ success: false, error: 'missing_credentials' });
+    }
+
+    const { rowCount } = await pool.query(
+      `UPDATE push_subscriptions SET active = false, updated_at = NOW()
+       WHERE id = $1 AND manage_token_hash = $2`,
+      [id, hashManageToken(manageToken)],
+    );
+
+    if (!rowCount) {
+      return res.status(404).json({ success: false, error: 'not_found' });
+    }
+
+    res.json({ success: true, ok: true });
+  });
+
+  router.post('/test', async (req, res) => {
+    try {
+      requireVapid();
+    } catch {
+      return res.status(503).json({ success: false, error: 'not_configured' });
+    }
+
+    const { id, manageToken } = req.body || {};
+    const { rows } = await pool.query(
+      `SELECT id, endpoint, p256dh, auth FROM push_subscriptions
+       WHERE id = $1 AND manage_token_hash = $2 AND active = true`,
+      [id, hashManageToken(manageToken)],
+    );
+
+    if (!rows.length) {
+      return res.status(404).json({ success: false, error: 'not_found' });
+    }
+
+    const result = await sendPushToSubscription(
+      pool,
+      rows[0],
+      { title: 'Elektros kaina LT', body: 'Push test OK', url: '/' },
+      `test:${Date.now()}`,
+    );
+
+    if (!result.ok) {
+      return res.status(502).json({ success: false, error: result.error });
+    }
+
+    res.json({ success: true, ok: true });
+  });
+
+  return router;
+}

--- a/backend/src/push/tokens.js
+++ b/backend/src/push/tokens.js
@@ -1,0 +1,9 @@
+import crypto from 'node:crypto';
+
+export function hashManageToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+export function createManageToken() {
+  return crypto.randomBytes(24).toString('hex');
+}

--- a/backend/src/push/vapid.js
+++ b/backend/src/push/vapid.js
@@ -1,0 +1,27 @@
+import webpush from 'web-push';
+
+let vapidConfigured = false;
+
+export function getVapidConfig() {
+  const publicKey = process.env.VAPID_PUBLIC_KEY || '';
+  const privateKey = process.env.VAPID_PRIVATE_KEY || '';
+  const subject = process.env.VAPID_SUBJECT || 'mailto:ops@example.com';
+  return { publicKey, privateKey, subject };
+}
+
+export function isPushConfigured() {
+  const { publicKey, privateKey } = getVapidConfig();
+  return Boolean(publicKey && privateKey);
+}
+
+export function requireVapid() {
+  const config = getVapidConfig();
+  if (!config.publicKey || !config.privateKey) {
+    throw new Error('VAPID keys not configured');
+  }
+  if (!vapidConfigured) {
+    webpush.setVapidDetails(config.subject, config.publicKey, config.privateKey);
+    vapidConfigured = true;
+  }
+  return config;
+}

--- a/backend/src/test.js
+++ b/backend/src/test.js
@@ -23,6 +23,8 @@ import {
   parseAllowBackupFlag,
   resolveBackupFetchPlan,
 } from './lib/prices/backupFetchPolicy.js';
+import { hashManageToken, createManageToken } from './push/tokens.js';
+import { getVapidConfig, isPushConfigured } from './push/vapid.js';
 
 let passed = 0;
 let failed = 0;
@@ -200,6 +202,32 @@ await testAsync('withBackupFetchGuard rate-limits duplicate keys', async () => {
   const second = await withBackupFetchGuard(key, async () => 'again');
   assert.equal(second.status, 'rate_limited');
   resetBackupFetchGuard();
+});
+
+test('push manage token hash is deterministic', () => {
+  const token = 'abc123';
+  assert.equal(hashManageToken(token), hashManageToken(token));
+  assert.notEqual(hashManageToken(token), hashManageToken('other'));
+});
+
+test('createManageToken returns hex string', () => {
+  const token = createManageToken();
+  assert.match(token, /^[0-9a-f]{48}$/);
+});
+
+test('isPushConfigured is false without VAPID env', () => {
+  const prevPublic = process.env.VAPID_PUBLIC_KEY;
+  const prevPrivate = process.env.VAPID_PRIVATE_KEY;
+  delete process.env.VAPID_PUBLIC_KEY;
+  delete process.env.VAPID_PRIVATE_KEY;
+  assert.equal(isPushConfigured(), false);
+  if (prevPublic) process.env.VAPID_PUBLIC_KEY = prevPublic;
+  if (prevPrivate) process.env.VAPID_PRIVATE_KEY = prevPrivate;
+});
+
+test('getVapidConfig defaults subject', () => {
+  const config = getVapidConfig();
+  assert.equal(config.subject, 'mailto:ops@example.com');
 });
 
 console.log(`\nTest results: ${passed} passed, ${failed} failed`);

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -20,8 +20,13 @@ import {
 } from './lib/admin/cronSchedules.js';
 import { getPriceData, getPriceDataAll, getLatestPrice, getCurrentPrice, getAvailableCountries, getSettings, updateSetting, getCurrentHourPrice, getLatestPriceAll, getCurrentHourPriceAll, getLatestTimestamp, logSync, getAllEarliestTimestamps, getInitialSyncStatus, getDatabaseStats, getSystemHealth, getAllCountrySyncStatus } from './database.js';
 import pool from './database.js';
+import { createPushRouter } from './push/router.js';
+import { createPushAdminRouter } from './push/adminRouter.js';
 
 const router = express.Router();
+
+router.use('/push', createPushRouter({ pool }));
+router.use('/admin/push', requireAdminToken, createPushAdminRouter({ pool }));
 
 // Get available countries
 router.get('/countries', async (req, res) => {

--- a/bin/validate-openapi-routes.js
+++ b/bin/validate-openapi-routes.js
@@ -20,17 +20,35 @@ function expressPathToOpenApi(routePath) {
   return routePath.replace(/:([A-Za-z_][A-Za-z0-9_]*)/g, '{$1}');
 }
 
-function extractV1Routes(source) {
+function extractV1Routes(source, prefix = '') {
   const routes = new Map();
   const pattern = /router\.(get|post|put|delete|patch)\(\s*['"]([^'"]+)['"]/g;
   let match = pattern.exec(source);
   while (match) {
     const method = match[1].toUpperCase();
-    const openApiPath = expressPathToOpenApi(match[2]);
+    const openApiPath = prefix + expressPathToOpenApi(match[2]);
     const key = `${method} ${openApiPath}`;
     routes.set(key, { method, path: openApiPath });
     match = pattern.exec(source);
   }
+  return routes;
+}
+
+function loadRouteMaps() {
+  const routes = new Map();
+  const routeFiles = [
+    { file: 'backend/src/v1.js', prefix: '' },
+    { file: 'backend/src/push/router.js', prefix: '/push' },
+    { file: 'backend/src/push/adminRouter.js', prefix: '/admin/push' },
+  ];
+
+  for (const { file, prefix } of routeFiles) {
+    const source = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+    for (const [key, route] of extractV1Routes(source, prefix)) {
+      routes.set(key, route);
+    }
+  }
+
   return routes;
 }
 
@@ -48,9 +66,8 @@ function extractOpenApiPaths(doc) {
   return routes;
 }
 
-const v1Source = fs.readFileSync(v1Path, 'utf8');
 const openApiDoc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
-const v1Routes = extractV1Routes(v1Source);
+const v1Routes = loadRouteMaps();
 const specRoutes = extractOpenApiPaths(openApiDoc);
 
 const missingInSpec = [];

--- a/database/init/01_schema.sql
+++ b/database/init/01_schema.sql
@@ -438,3 +438,40 @@ INSERT INTO cron_schedules (job_key, name, cron_expression, timezone, descriptio
 ('next_day_sync', 'Next Day Sync', '30 13 * * *', 'Europe/Paris', 'Every day at 13:30 Paris time after Nord Pool publish window', true),
 ('daily_sync', 'Daily Release Window Sync', 'dynamic', 'Europe/Paris', 'Dynamic scheduler during Nord Pool release window (read-only)', false)
 ON CONFLICT (job_key) DO NOTHING;
+
+-- Web Push subscriptions (optional PWA feature)
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id TEXT PRIMARY KEY,
+    endpoint TEXT NOT NULL UNIQUE,
+    p256dh TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    payload_json JSONB NOT NULL DEFAULT '{}',
+    manage_token_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error TEXT,
+    active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_active ON push_subscriptions (active);
+
+CREATE TABLE IF NOT EXISTS push_sent_log (
+    id BIGSERIAL PRIMARY KEY,
+    sub_id TEXT NOT NULL REFERENCES push_subscriptions (id),
+    dedupe_key TEXT NOT NULL,
+    sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (sub_id, dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_sent_log_sent_at ON push_sent_log (sent_at DESC);
+
+CREATE TABLE IF NOT EXISTS push_delivery_failures (
+    id BIGSERIAL PRIMARY KEY,
+    sub_id TEXT NOT NULL REFERENCES push_subscriptions (id),
+    dedupe_key TEXT,
+    error_message TEXT NOT NULL,
+    payload_json JSONB,
+    failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_delivery_failures_failed_at ON push_delivery_failures (failed_at DESC);

--- a/swagger-ui/openapi.json
+++ b/swagger-ui/openapi.json
@@ -2119,6 +2119,163 @@
           }
         }
       }
+    },
+    "/push/vapid-public": {
+      "get": {
+        "summary": "Get VAPID public key for push subscription",
+        "tags": [
+          "Push"
+        ],
+        "responses": {
+          "200": {
+            "description": "Public key for client pushManager.subscribe"
+          },
+          "503": {
+            "description": "Push not configured"
+          }
+        }
+      }
+    },
+    "/push/status": {
+      "get": {
+        "summary": "Whether push is configured on the server",
+        "tags": [
+          "Push"
+        ],
+        "responses": {
+          "200": {
+            "description": "Configuration status"
+          }
+        }
+      }
+    },
+    "/push/subscribe": {
+      "post": {
+        "summary": "Register web push subscription",
+        "tags": [
+          "Push"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Subscription stored"
+          },
+          "400": {
+            "description": "Invalid subscription payload"
+          },
+          "503": {
+            "description": "Push not configured"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Deactivate web push subscription",
+        "tags": [
+          "Push"
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription deactivated"
+          }
+        }
+      }
+    },
+    "/push/test": {
+      "post": {
+        "summary": "Send test push to own subscription",
+        "tags": [
+          "Push"
+        ],
+        "responses": {
+          "200": {
+            "description": "Notification sent"
+          },
+          "404": {
+            "description": "Subscription not found"
+          }
+        }
+      }
+    },
+    "/admin/push/stats": {
+      "get": {
+        "summary": "Push subscription and delivery stats (admin)",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stats payload"
+          }
+        }
+      }
+    },
+    "/admin/push/deliveries": {
+      "get": {
+        "summary": "Recent push deliveries and failures (admin)",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delivery log"
+          }
+        }
+      }
+    },
+    "/admin/push/test": {
+      "post": {
+        "summary": "Send test push to subscription by id (admin)",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notification sent"
+          }
+        }
+      }
+    },
+    "/admin/push/broadcast": {
+      "post": {
+        "summary": "Broadcast push to active subscriptions (admin)",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "AdminToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Broadcast summary"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -1411,6 +1411,107 @@ paths:
         '404':
           description: 'Unknown job key'
 
+  /push/vapid-public:
+    get:
+      summary: 'Get VAPID public key for push subscription'
+      tags:
+        - Push
+      responses:
+        '200':
+          description: 'Public key for client pushManager.subscribe'
+        '503':
+          description: 'Push not configured'
+
+  /push/status:
+    get:
+      summary: 'Whether push is configured on the server'
+      tags:
+        - Push
+      responses:
+        '200':
+          description: 'Configuration status'
+
+  /push/subscribe:
+    post:
+      summary: 'Register web push subscription'
+      tags:
+        - Push
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: 'Subscription stored'
+        '400':
+          description: 'Invalid subscription payload'
+        '503':
+          description: 'Push not configured'
+    delete:
+      summary: 'Deactivate web push subscription'
+      tags:
+        - Push
+      responses:
+        '200':
+          description: 'Subscription deactivated'
+
+  /push/test:
+    post:
+      summary: 'Send test push to own subscription'
+      tags:
+        - Push
+      responses:
+        '200':
+          description: 'Notification sent'
+        '404':
+          description: 'Subscription not found'
+
+  /admin/push/stats:
+    get:
+      summary: 'Push subscription and delivery stats (admin)'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      responses:
+        '200':
+          description: 'Stats payload'
+
+  /admin/push/deliveries:
+    get:
+      summary: 'Recent push deliveries and failures (admin)'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      responses:
+        '200':
+          description: 'Delivery log'
+
+  /admin/push/test:
+    post:
+      summary: 'Send test push to subscription by id (admin)'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      responses:
+        '200':
+          description: 'Notification sent'
+
+  /admin/push/broadcast:
+    post:
+      summary: 'Broadcast push to active subscriptions (admin)'
+      tags:
+        - Admin
+      security:
+        - AdminToken: []
+      responses:
+        '200':
+          description: 'Broadcast summary'
+
 components:
   schemas:
     Country:


### PR DESCRIPTION
## Summary
- Add `backend/src/push/` module: VAPID config, subscription CRUD, delivery with sent log and failure dead-letter.
- Admin routes: stats, deliveries, test, broadcast (protected by `ADMIN_API_TOKEN`).
- Postgres schema for `push_subscriptions`, `push_sent_log`, `push_delivery_failures`.
- Document VAPID env vars in `.env.example` and `COOLIFY_DEPLOYMENT.md`; extend OpenAPI and route validator.

Fixes #15

## Test plan
- [x] `npm test --prefix backend` (21 tests incl. push token/vapid helpers)
- [x] `node bin/validate-openapi-routes.js`
- [ ] Manual: set VAPID keys, POST `/api/v1/push/subscribe`, admin test broadcast


Made with [Cursor](https://cursor.com)