### PR TITLE
docs(admin): push statistics operator guide (#14)

### DIFF
--- a/COOLIFY_DEPLOYMENT.md
+++ b/COOLIFY_DEPLOYMENT.md
@@ -127,6 +127,8 @@ VAPID_PRIVATE_KEY=your_vapid_private_key
 VAPID_SUBJECT=mailto:ops@yourdomain.com
 ```
 
+See [docs/ops/push-admin.md](docs/ops/push-admin.md) for operator curl examples and export notes.
+
 **Important Notes**:
 - **Replace `your_secure_password_here`** with a strong, unique password
 - Use the **same password** for both `POSTGRES_PASSWORD` and in `DATABASE_URL`

--- a/docs/ops/push-admin.md
+++ b/docs/ops/push-admin.md
@@ -1,0 +1,115 @@
+# Push admin API and statistics
+
+Operator guide for the protected `/api/v1/admin/push/*` endpoints shipped in #15. Use this for subscription counts, delivery logs, test sends, and broadcasts until a full admin UI exists (#14 follow-ups).
+
+## Prerequisites
+
+| Variable | Purpose |
+| --- | --- |
+| `ADMIN_API_TOKEN` | Bearer or `X-Admin-Token` on every admin request |
+| `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` | Required for `/test` and `/broadcast` only |
+
+Generate VAPID keys:
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Set keys in Coolify env or local `.env` (see [COOLIFY_DEPLOYMENT.md](../../COOLIFY_DEPLOYMENT.md)).
+
+Interactive reference: Swagger UI at `/api/` → **Admin** tag.
+
+## Authentication
+
+```bash
+export ADMIN_TOKEN="your_admin_api_token"
+export API_BASE="https://elektra.teletigras.lt/api/v1"
+```
+
+Send either header:
+
+- `Authorization: Bearer $ADMIN_TOKEN`
+- `X-Admin-Token: $ADMIN_TOKEN`
+
+Optional audit actor: `X-Admin-Actor: ops@example.com`
+
+## Endpoints
+
+### GET `/admin/push/stats`
+
+Aggregates active/total push subscriptions and 24-hour send/failure counts.
+
+```bash
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$API_BASE/admin/push/stats" | jq
+```
+
+Example response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "subscriptions": { "active": 12, "total": 15 },
+    "last24h": { "sent": 48, "failures": 1 },
+    "configured": true
+  }
+}
+```
+
+`configured` reflects VAPID presence; stats still return when VAPID is unset.
+
+### GET `/admin/push/deliveries`
+
+Recent sent notifications and failures (newest first). Query: `limit` (1–200, default 50).
+
+```bash
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$API_BASE/admin/push/deliveries?limit=20" | jq
+```
+
+Endpoints in the response are push service URLs (not user PII). Retention follows DB tables `push_sent_log` and `push_delivery_failures`.
+
+### POST `/admin/push/test`
+
+Send a test notification to one subscription by database id.
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"subscriptionId":1,"title":"Test","body":"Hello","url":"/today"}' \
+  "$API_BASE/admin/push/test"
+```
+
+### POST `/admin/push/broadcast`
+
+Send to all active subscriptions (or all if `activeOnly: false`).
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Prices updated","body":"Tomorrow prices are available","url":"/upcoming"}' \
+  "$API_BASE/admin/push/broadcast"
+```
+
+## Export for analysis
+
+Pipe JSON to a file (no built-in CSV yet):
+
+```bash
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$API_BASE/admin/push/stats" > push-stats-$(date -u +%Y%m%d).json
+
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$API_BASE/admin/push/deliveries?limit=200" > push-deliveries-$(date -u +%Y%m%d).json
+```
+
+## Privacy and scope
+
+- Default views expose subscription ids and push endpoints only; no email or device names.
+- **Not in this API (deferred):** PWA install counts, per-country breakdown, time-range filters beyond 24h, silent-push effectiveness metrics. Track in follow-up issues if needed.
+
+## Related issues
+
+- #15 — push admin API (implemented)
+- #14 — full statistics dashboard (this doc satisfies minimal wiring; UI/filters deferred)

--- a/swagger-ui/openapi.json
+++ b/swagger-ui/openapi.json
@@ -2208,8 +2208,10 @@
     "/admin/push/stats": {
       "get": {
         "summary": "Push subscription and delivery stats (admin)",
+        "description": "Active/total subscriptions and 24h send/failure counts. See docs/ops/push-admin.md.",
         "tags": [
-          "Admin"
+          "Admin",
+          "Push"
         ],
         "security": [
           {
@@ -2218,7 +2220,20 @@
         ],
         "responses": {
           "200": {
-            "description": "Stats payload"
+            "description": "Stats payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing admin token"
+          },
+          "503": {
+            "description": "ADMIN_API_TOKEN not configured"
           }
         }
       }
@@ -2226,17 +2241,41 @@
     "/admin/push/deliveries": {
       "get": {
         "summary": "Recent push deliveries and failures (admin)",
+        "description": "Newest-first delivery log. Query limit 1–200 (default 50).",
         "tags": [
-          "Admin"
+          "Admin",
+          "Push"
         ],
         "security": [
           {
             "AdminToken": []
           }
         ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Delivery log"
+            "description": "Delivery log",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushDeliveriesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing admin token"
           }
         }
       }
@@ -2245,16 +2284,39 @@
       "post": {
         "summary": "Send test push to subscription by id (admin)",
         "tags": [
-          "Admin"
+          "Admin",
+          "Push"
         ],
         "security": [
           {
             "AdminToken": []
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushTestRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Notification sent"
+          },
+          "400": {
+            "description": "Missing subscriptionId"
+          },
+          "404": {
+            "description": "Subscription not found"
+          },
+          "502": {
+            "description": "Delivery failed"
+          },
+          "503": {
+            "description": "VAPID not configured"
           }
         }
       }
@@ -2263,16 +2325,40 @@
       "post": {
         "summary": "Broadcast push to active subscriptions (admin)",
         "tags": [
-          "Admin"
+          "Admin",
+          "Push"
         ],
         "security": [
           {
             "AdminToken": []
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushBroadcastRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Broadcast summary"
+            "description": "Broadcast summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushBroadcastResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing title or body"
+          },
+          "503": {
+            "description": "VAPID not configured"
           }
         }
       }
@@ -2501,6 +2587,139 @@
           "timestamp": "2025-06-26T00:15:30.024Z",
           "path": "/api/v1/nps/price/lt/latest"
         }
+      },
+      "PushStatsResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "subscriptions": {
+                "type": "object",
+                "properties": {
+                  "active": {
+                    "type": "integer",
+                    "example": 12
+                  },
+                  "total": {
+                    "type": "integer",
+                    "example": 15
+                  }
+                }
+              },
+              "last24h": {
+                "type": "object",
+                "properties": {
+                  "sent": {
+                    "type": "integer",
+                    "example": 48
+                  },
+                  "failures": {
+                    "type": "integer",
+                    "example": 1
+                  }
+                }
+              },
+              "configured": {
+                "type": "boolean",
+                "description": "Whether VAPID keys are set"
+              }
+            }
+          }
+        }
+      },
+      "PushDeliveriesResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "sent": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "failures": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "PushTestRequest": {
+        "type": "object",
+        "required": [
+          "subscriptionId"
+        ],
+        "properties": {
+          "subscriptionId": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "PushBroadcastRequest": {
+        "type": "object",
+        "required": [
+          "title",
+          "body"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "activeOnly": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "PushBroadcastResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "targeted": {
+                "type": "integer"
+              },
+              "sent": {
+                "type": "integer"
+              },
+              "failed": {
+                "type": "integer"
+              }
+            }
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -2535,6 +2754,10 @@
     {
       "name": "Admin",
       "description": "Protected admin API (ADMIN_API_TOKEN)"
+    },
+    {
+      "name": "Push",
+      "description": "Web push subscriptions and admin delivery (see docs/ops/push-admin.md)"
     },
     {
       "name": "Legacy",

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -1471,46 +1471,102 @@ paths:
   /admin/push/stats:
     get:
       summary: 'Push subscription and delivery stats (admin)'
+      description: 'Active/total subscriptions and 24h send/failure counts. See docs/ops/push-admin.md.'
       tags:
         - Admin
+        - Push
       security:
         - AdminToken: []
       responses:
         '200':
           description: 'Stats payload'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushStatsResponse'
+        '401':
+          description: 'Invalid or missing admin token'
+        '503':
+          description: 'ADMIN_API_TOKEN not configured'
 
   /admin/push/deliveries:
     get:
       summary: 'Recent push deliveries and failures (admin)'
+      description: 'Newest-first delivery log. Query limit 1–200 (default 50).'
       tags:
         - Admin
+        - Push
       security:
         - AdminToken: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
       responses:
         '200':
           description: 'Delivery log'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushDeliveriesResponse'
+        '401':
+          description: 'Invalid or missing admin token'
 
   /admin/push/test:
     post:
       summary: 'Send test push to subscription by id (admin)'
       tags:
         - Admin
+        - Push
       security:
         - AdminToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushTestRequest'
       responses:
         '200':
           description: 'Notification sent'
+        '400':
+          description: 'Missing subscriptionId'
+        '404':
+          description: 'Subscription not found'
+        '502':
+          description: 'Delivery failed'
+        '503':
+          description: 'VAPID not configured'
 
   /admin/push/broadcast:
     post:
       summary: 'Broadcast push to active subscriptions (admin)'
       tags:
         - Admin
+        - Push
       security:
         - AdminToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushBroadcastRequest'
       responses:
         '200':
           description: 'Broadcast summary'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushBroadcastResponse'
+        '400':
+          description: 'Missing title or body'
+        '503':
+          description: 'VAPID not configured'
 
 components:
   schemas:
@@ -1666,6 +1722,94 @@ components:
         code: 'NO_DATA_FOUND'
         timestamp: '2025-06-26T00:15:30.024Z'
         path: '/api/v1/nps/price/lt/latest'
+    PushStatsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          properties:
+            subscriptions:
+              type: object
+              properties:
+                active:
+                  type: integer
+                  example: 12
+                total:
+                  type: integer
+                  example: 15
+            last24h:
+              type: object
+              properties:
+                sent:
+                  type: integer
+                  example: 48
+                failures:
+                  type: integer
+                  example: 1
+            configured:
+              type: boolean
+              description: 'Whether VAPID keys are set'
+    PushDeliveriesResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            sent:
+              type: array
+              items:
+                type: object
+            failures:
+              type: array
+              items:
+                type: object
+    PushTestRequest:
+      type: object
+      required:
+        - subscriptionId
+      properties:
+        subscriptionId:
+          type: integer
+        title:
+          type: string
+        body:
+          type: string
+        url:
+          type: string
+    PushBroadcastRequest:
+      type: object
+      required:
+        - title
+        - body
+      properties:
+        title:
+          type: string
+        body:
+          type: string
+        url:
+          type: string
+        activeOnly:
+          type: boolean
+          default: true
+    PushBroadcastResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            targeted:
+              type: integer
+            sent:
+              type: integer
+            failed:
+              type: integer
   securitySchemes:
     AdminToken:
       type: apiKey
@@ -1684,5 +1828,7 @@ tags:
     description: 'Sync worker status and admin triggers'
   - name: Admin
     description: 'Protected admin API (ADMIN_API_TOKEN)'
+  - name: Push
+    description: 'Web push subscriptions and admin delivery (see docs/ops/push-admin.md)'
   - name: Legacy
     description: 'Deprecated compatibility endpoints; prefer /nps/* equivalents'


### PR DESCRIPTION
## Summary
- Add `docs/ops/push-admin.md` with curl examples for `/admin/push/stats`, `/deliveries`, `/test`, and `/broadcast`
- Enrich OpenAPI schemas and Push tag for Swagger UI
- Link from COOLIFY_DEPLOYMENT.md

Minimal wiring to #15 API; full dashboard UI, PWA install counts, and time-range filters deferred.

## Test plan
- [x] `node bin/openapi-json-from-yaml.js --write`
- [x] `node bin/validate-openapi-routes.js`

Fixes #14

Made with [Cursor](https://cursor.com)