### PR TITLE
fix(pwa): wire push subscribe to backend productPayload

### DIFF
--- a/electricity-prices-build/src/components/PriceTable.vue
+++ b/electricity-prices-build/src/components/PriceTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, onMounted, onUnmounted } from 'vue';
 import moment from 'moment-timezone';
 import { formatPriceHours, isCurrentHour } from '../services/timeService';
 import { calculatePrice, getTimePeriod } from '../services/priceCalculationService';
@@ -57,6 +57,18 @@ watch(() => props.priceData, (newData) => {
 }, { deep: true });
 
 const settings = ref(getColorThresholdSettings());
+
+function onAlertSettingsUpdated(event) {
+  settings.value = { ...event.detail.colorThresholds };
+}
+
+onMounted(() => {
+  window.addEventListener('alertSettingsUpdated', onAlertSettingsUpdated);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('alertSettingsUpdated', onAlertSettingsUpdated);
+});
 
 const averagePrice = computed(() => {
   // Use allPriceData for average calculation if provided, otherwise use priceData

--- a/electricity-prices-build/src/services/pushNotificationService.js
+++ b/electricity-prices-build/src/services/pushNotificationService.js
@@ -138,7 +138,7 @@ export async function subscribeToPush(settings = loadAlertSettings()) {
     }
 
     return postSubscribeBody({
-      alertPreferences: getSubscriptionMetadata(settings),
+      productPayload: getSubscriptionMetadata(settings),
       timezone: settings.timezone,
       pushSubscription: sub.toJSON(),
     });
@@ -148,28 +148,26 @@ export async function subscribeToPush(settings = loadAlertSettings()) {
 }
 
 export async function syncPushSubscription(settings = loadAlertSettings()) {
-  const id = localStorage.getItem(SUB_ID_KEY);
-  const manageToken = localStorage.getItem(MANAGE_TOKEN_KEY);
-  if (!id || !manageToken) {
+  const env = getPushEnvironmentStatus();
+  if (!env.ready || !('serviceWorker' in navigator)) {
     return { ok: false, skipped: true };
   }
 
-  const res = await fetch(subscribeUrl(), {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      id,
-      manageToken,
-      alertPreferences: getSubscriptionMetadata(settings),
+  try {
+    const reg = await navigator.serviceWorker.getRegistration(SW_SCOPE);
+    const sub = reg ? await reg.pushManager.getSubscription() : null;
+    if (!sub) {
+      return { ok: false, skipped: true };
+    }
+
+    return postSubscribeBody({
+      productPayload: getSubscriptionMetadata(settings),
       timezone: settings.timezone,
-    }),
-  });
-
-  if (res.status === 404) {
-    return { ok: false, unavailable: true };
+      pushSubscription: sub.toJSON(),
+    });
+  } catch {
+    return { ok: false, skipped: true };
   }
-
-  return { ok: res.ok };
 }
 
 export async function unsubscribeFromPush() {


### PR DESCRIPTION
## Summary
- Send unified alert settings as `productPayload` on `POST /api/v1/push/subscribe` (matches backend #87 contract)
- Re-post subscription on settings change instead of unsupported `PUT`
- `PriceTable` reacts to `alertSettingsUpdated` for live color threshold updates

## Test plan
- [x] `npm test --prefix electricity-prices-build`
- [x] `npm run build --prefix electricity-prices-build`

Refs #16

Made with [Cursor](https://cursor.com)