### PR TITLE
docs(spikes): Google News and Android widget feasibility (#22, #23)

### DIFF
--- a/docs/spikes/android-twa-widget.md
+++ b/docs/spikes/android-twa-widget.md
@@ -1,0 +1,33 @@
+# Android home screen widget spike (#23)
+
+**Decision (2026-06):** Standard PWA cannot expose Android App Widgets. Interim UX: manifest shortcuts. Full widget requires TWA + native Kotlin.
+
+## Platform matrix
+
+| Approach | Android widget | Cost | Notes |
+| --- | --- | --- | --- |
+| PWA / WebAPK (Chrome install) | No | Low | No widget API for installed PWAs ([Chromium #1170639](https://bugs.chromium.org/p/chromium/issues/detail?id=1170639)) |
+| Manifest shortcuts | No (launcher shortcuts only) | Low | Deep-link to `/today`, `/upcoming` |
+| TWA (Bubblewrap / PWA Builder) | Yes, with native code | Medium | Wrap PWA in Play Store APK; `AppWidgetProvider` still required |
+| Edge PWA Widgets (Windows 11) | N/A on Android | — | Experimental; not available on Android |
+
+## Proposed phases
+
+1. **Phase A (web-native):** Manifest `shortcuts` to `/today` and `/upcoming` (flows `manifest.webmanifest.example` pattern)
+2. **Phase B (Android widget):** Separate minimal Android app (TWA shell + `AppWidgetProvider`) fetching `/api/v1/nps/prices/today` summary; Digital Asset Links with web origin
+3. **Phase C (optional):** iOS widget via WidgetKit (separate native target)
+
+## Widget refresh policy
+
+Align polling with release-window phases (#17, #8): avoid aggressive refresh outside Nord Pool publication windows.
+
+## Relevant paths
+
+- `electricity-prices-build/public/site.webmanifest`
+- flows reference: `vendor/flows/components/pwa/manifest.webmanifest.example`
+- Future Phase B: new `android/` TWA project (out of scope for web-only revamp)
+
+## References
+
+- [web.dev WebAPKs](https://web.dev/articles/webapks)
+- [MSEdgeExplainers PWAWidgets](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PWAWidgets/README.md)

--- a/docs/spikes/google-news-decision.md
+++ b/docs/spikes/google-news-decision.md
@@ -1,0 +1,49 @@
+# Google News feasibility spike — decision record
+
+**Issue:** #22  
+**Date:** 2026-06-15  
+**Decision:** **No-go** for Google News placement in the current product scope.
+
+## Context
+
+Stakeholder asked whether syndicating electricity price data via Google News would add credibility for the Nordpool price monitor.
+
+## Findings
+
+| Factor | Finding |
+| --- | --- |
+| Eligibility | Google News surfaces require **news-focused, original, timely editorial content** with clear dates and bylines — not utility dashboards or raw JSON feeds |
+| Publisher Center | No application required; as of March 2025 Google auto-generates publication pages; RSS/web-location submissions in Publisher Center are **deprecated** ([Google support](https://support.google.com/news/publisher-center/answer/15898024)) |
+| News sitemap | Helps **news articles** only; useless without article HTML pages |
+| This product today | Interactive price app + API — **not eligible** for Google News as-is |
+
+## Go / no-go
+
+**No-go** for Google News as a near-term initiative.
+
+Rationale:
+
+1. Placement requires an **editorial content product** (daily digest articles, author metadata, `NewsArticle` JSON-LD, news sitemap) — a pivot from the current data/utility app.
+2. Expected ROI is low versus **Search SEO** work tracked in #21 (Dataset rich results, sitemap, Search Console baseline in [search-console.md](../ops/search-console.md)).
+3. Auto-generated digests risk thin-content penalties unless staffed with editorial review.
+
+## If revisited later (conditional go path)
+
+Only pursue after explicit PO approval of a content track:
+
+1. **Article template** — e.g. daily digest: "Elektros kainos YYYY-MM-DD: vidutinė X ct/kWh…"
+2. **Generation trigger** — post-sync hook when tomorrow prices publish (#8 release window)
+3. **URL scheme** — `/news/YYYY-MM-DD` with static/SSG HTML
+4. **Structured data** — `NewsArticle` JSON-LD + dedicated news sitemap
+5. **Search Console** — verify indexing baseline regardless (see [search-console.md](../ops/search-console.md))
+
+## Out of scope (unchanged focus)
+
+- Google News Publisher Center setup
+- News sitemap or RSS for Google News submission
+- Editorial CMS or digest generation
+
+## Related
+
+- #21 — SERP improvements (recommended path)
+- [search-console.md](../ops/search-console.md) — verification and sitemap baseline

--- a/docs/spikes/google-news-feasibility.md
+++ b/docs/spikes/google-news-feasibility.md
@@ -1,0 +1,40 @@
+# Spike: Google News daily price digest (#22)
+
+**Status:** No-go for Google News placement without an editorial product layer.  
+**Date:** 2026-06-15  
+**Related:** #21 SERP baseline, #22
+
+## Question
+
+Would submitting to Google News add credibility for an electricity price monitor?
+
+## Findings
+
+| Factor | Finding |
+| --- | --- |
+| Eligibility | Google News requires **news-focused, original, timely editorial content** with dates and bylines — not utility dashboards or raw API JSON |
+| Publisher Center | No application required; as of March 2025 Google auto-generates publication pages; RSS submissions in Publisher Center are deprecated |
+| News sitemap | Helps **article HTML** discovery only; useless without `/news/...` pages |
+| This product today | Interactive PWA + API — **not eligible** for Google News as-is |
+
+## Decision
+
+**No-go** for Google News in the current product shape. Continue Search-focused SEO (#21): Dataset JSON-LD, hreflang, build sitemap, Search Console monitoring.
+
+## If stakeholder reopens (go path)
+
+1. **Content:** Auto-generated daily digest articles (LT/EN) after sync completes — e.g. `/news/2026-06-15`
+2. **Schema:** `NewsArticle` JSON-LD with `datePublished`, author, headline
+3. **Sitemap:** Separate news sitemap generator alongside existing build sitemap
+4. **Trigger:** Post-sync hook when `initial_sync_completed` and today's LT prices are complete
+5. **Effort:** Content product pivot (SSG or prerender route), not a manifest or feed tweak
+
+## Verification regardless of News
+
+- Search Console property verified and sitemap submitted (#21)
+- Monitor indexing for `/today`, `/upcoming`, `/about` — not News-specific
+
+## References
+
+- [Google Publisher Center — what's changed](https://support.google.com/news/publisher-center/answer/15898024)
+- Issue #22 acceptance criteria


### PR DESCRIPTION
## Summary
- `docs/spikes/google-news-decision.md` — no-go decision record for Google News
- `docs/spikes/android-twa-widget.md` — platform matrix and TWA phases

## Test plan
- [x] Docs only

Fixes #22
Fixes #23

Made with [Cursor](https://cursor.com)