### PR TITLE
fix(smoke): resolve local vite on Windows for smoke-local

### DIFF
--- a/bin/smoke-local.sh
+++ b/bin/smoke-local.sh
@@ -34,7 +34,8 @@ test -f .env.example
 if command -v npm >/dev/null 2>&1; then
   echo "==> frontend build"
   npm ci --prefix electricity-prices-build
-  npm run build --prefix electricity-prices-build
+  # npx resolves local vite on Windows where bare "vite" is not on PATH in npm scripts
+  npm exec --prefix electricity-prices-build -- vite build
 fi
 
 if curl -sf "${API_URL}/health" >/dev/null 2>&1; then

--- a/electricity-prices-build/package.json
+++ b/electricity-prices-build/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "test": "vitest run"
+    "dev": "npx vite",
+    "build": "npx vite build",
+    "preview": "npx vite preview",
+    "test": "npx vitest run"
   },
   "dependencies": {
     "@vuepic/vue-datepicker": "14.0.0",


### PR DESCRIPTION
## Summary
- Use `npx vite` in frontend `package.json` scripts so `npm run build` works on Windows cmd without a global vite install
- Call `npm exec vite build` in `bin/smoke-local.sh` for the same PATH behavior during local smoke checks

## Problem
On Windows, `npm run build` failed with `'vite' is not recognized` because cmd.exe does not reliably resolve `node_modules/.bin/vite` for bare script commands.

## Test plan
- [x] CI lint-and-unit (includes frontend build)
- [ ] `./bin/smoke-local.sh` on Windows after clean `npm ci` (operator verify)

Fixes #93

Made with [Cursor](https://cursor.com)