### PR TITLE
fix(smoke): normalize EOL in openapi --check (#94)

### DIFF
--- a/bin/openapi-json-from-yaml.js
+++ b/bin/openapi-json-from-yaml.js
@@ -15,6 +15,11 @@ const yaml = require('js-yaml');
 const yamlPath = path.join(repoRoot, 'swagger-ui/openapi.yaml');
 const jsonPath = path.join(repoRoot, 'swagger-ui/openapi.json');
 
+/** Normalize CRLF/CR to LF so --check is stable on Windows (core.autocrlf). */
+function normalizeEol(text) {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
 const mode = process.argv.includes('--write') ? '--write' : '--check';
 const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
 const generated = `${JSON.stringify(doc, null, 2)}\n`;
@@ -24,7 +29,7 @@ if (mode === '--write') {
   console.log(`Wrote ${path.relative(repoRoot, jsonPath)} from openapi.yaml`);
 } else {
   const existing = fs.existsSync(jsonPath) ? fs.readFileSync(jsonPath, 'utf8') : '';
-  if (existing !== generated) {
+  if (normalizeEol(existing) !== generated) {
     console.error('openapi.json is out of sync with openapi.yaml (source of truth).');
     console.error('Run: node bin/openapi-json-from-yaml.js --write');
     process.exit(1);


### PR DESCRIPTION
## Summary
- Normalize CRLF/CR to LF in `bin/openapi-json-from-yaml.js --check` before comparing `swagger-ui/openapi.json` to generated output
- Fixes false-positive smoke-local failures on Windows when `core.autocrlf` expands committed LF to CRLF in the working tree

Fixes #94

## Test plan
- [x] `node bin/openapi-json-from-yaml.js --check` passes with CRLF working-tree `openapi.json` on win32
- [x] LF working tree still passes

Made with [Cursor](https://cursor.com)