### PR TITLE
docs(ops): link Coolify password rotation runbook

### DIFF
--- a/COOLIFY_DEPLOYMENT.md
+++ b/COOLIFY_DEPLOYMENT.md
@@ -132,6 +132,7 @@ See [docs/ops/push-admin.md](docs/ops/push-admin.md) for operator curl examples 
 **Important Notes**:
 - **Replace `your_secure_password_here`** with a strong, unique password
 - Use the **same password** for both `POSTGRES_PASSWORD` and in `DATABASE_URL`
+- For production password rotation (issue #34), see [docs/ops/coolify-password-rotation.md](docs/ops/coolify-password-rotation.md)
 - Make sure `FRONTEND_PORT` matches the port in `FRONTEND_URL`
 - The optimized `docker-compose.coolify.yml` has **no hardcoded passwords** - all sensitive values must be set via environment variables
 
@@ -287,7 +288,7 @@ Use the default `docker-compose.yml` with:
 
 ## Security Considerations
 
-1. **Database Password**: Use a strong, unique password
+1. **Database Password**: Use a strong, unique password. Rotate production credentials per [docs/ops/coolify-password-rotation.md](docs/ops/coolify-password-rotation.md) (#34).
 2. **Environment Variables**: Never commit sensitive data to Git
 3. **Network**: Services should only be accessible internally (except frontend)
 4. **SSL/TLS**: If Coolify supports it, enable HTTPS for production

--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ Contributions require DCO sign-off; see [CONTRIBUTING.md](./CONTRIBUTING.md). Ci
 
 ## 📄 **Documentation**
 
+- [Coolify deployment](./COOLIFY_DEPLOYMENT.md) — production deploy guide
+- [Coolify password rotation](./docs/ops/coolify-password-rotation.md) — operator runbook (#34)
 - [Project Planning](./documentation/project_planning.md) - Detailed project documentation
 - [API Documentation](./electricity-prices-build/public/docs/swagger.yaml) - Swagger API specs
 - [Interactive API Docs](./api/) - Swagger UI interface


### PR DESCRIPTION
## Summary
- Link `docs/ops/coolify-password-rotation.md` from `COOLIFY_DEPLOYMENT.md` (env vars + security sections)
- Add Coolify deploy and password rotation links to README documentation section

Rotation runbook already landed in #92; this PR only adds discoverability cross-links.

Refs #34

## Test plan
- [x] Docs only; link targets exist

Made with [Cursor](https://cursor.com)