### PR TITLE
fix(frontend): bootstrap upcoming on empty DB and repair Today page UX

### DIFF
--- a/electricity-prices-build/src/components/PriceTable.vue
+++ b/electricity-prices-build/src/components/PriceTable.vue
@@ -211,7 +211,7 @@ const groupedByHour = computed(() => {
   <div v-if="!hasEnoughData" class="alert alert-warning" role="alert">
     <span v-html="$t('table.noData').replace('\n', '<br>')"></span>
   </div>
-  <div class="table-responsive">
+  <div v-else class="table-responsive">
     <table class="table table-hover align-middle">
       <thead>
         <tr>

--- a/electricity-prices-build/src/services/priceService.js
+++ b/electricity-prices-build/src/services/priceService.js
@@ -187,6 +187,39 @@ export async function fetchUpcomingPrices(country = 'lt', forceRefresh = false) 
       console.log('[Cache] Using cached upcoming data as fallback');
       return buildCachedResponse(cached, country, { phase, offline: true });
     }
+
+    const noDataInDb =
+      error.response?.status === 404 &&
+      error.response?.data?.code === 'NO_DATA_FOUND';
+
+    if (noDataInDb) {
+      console.log('[SmartSync] Upcoming empty in DB; bootstrapping today and tomorrow');
+      try {
+        const today = moment().tz(DISPLAY_TIMEZONE);
+        await fetchPrices(today.toDate(), country, { force: true });
+        await fetchPrices(today.clone().add(1, 'day').toDate(), country, { force: true });
+
+        const bootstrapped = getCachedUpcomingPrices(country);
+        if (bootstrapped && bootstrapped.length > 0) {
+          return buildCachedResponse(bootstrapped, country, { phase, bootstrapped: true });
+        }
+
+        const retry = await axios.get(apiUrl);
+        const retryData = retry.data;
+        if (retryData.success && retryData.data?.[country.toLowerCase()]) {
+          storeAndNotify(retryData.data[country.toLowerCase()], country);
+        }
+        return retryData;
+      } catch (bootstrapError) {
+        console.error('[SmartSync] Upcoming bootstrap failed:', bootstrapError);
+        const bootstrapped = getCachedUpcomingPrices(country);
+        if (bootstrapped && bootstrapped.length > 0) {
+          return buildCachedResponse(bootstrapped, country, { phase, bootstrapped: true, offline: true });
+        }
+        return buildCachedResponse([], country, { phase, noData: true });
+      }
+    }
+
     throw error;
   }
 }

--- a/electricity-prices-build/src/views/TodayView.vue
+++ b/electricity-prices-build/src/views/TodayView.vue
@@ -1,162 +1,183 @@
-<script setup>
-import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
-import { useRoute } from 'vue-router'
-import moment from 'moment-timezone';
-import { fetchPrices, onPricesUpdated, runSmartSync } from '../services/priceService';
-import { calculatePrice, logAllPriceBreakdowns } from '../services/priceCalculationService';
-import PriceTable from '../components/PriceTable.vue';
-import i18n from '../i18n';
-import {
-  setSEO,
-  buildRouteStructuredData,
-  generatePriceDataStructuredData,
-} from '../utils/seo';
-
-moment.tz.setDefault("Europe/Vilnius");
-
-const route = useRoute();
-const date = ref(new Date());
-const minDate = ref(new Date("2012-07-01"));
-const priceData = ref([]);
-const nextDay = moment().add(1, 'days').format('YYYY-MM-DD');
-
-let refreshTimeout = null;
-let unsubscribePrices = null;
-
-function getIntervalMs() {
-  if (priceData.value && priceData.value.length >= 2) {
-    const diffSec = priceData.value[1].timestamp - priceData.value[0].timestamp;
-    if (diffSec > 0) return diffSec * 1000;
-  }
-  return 60 * 60 * 1000; // default 1 hour
-}
-
-function scheduleNextRefresh() {
-  if (refreshTimeout) clearTimeout(refreshTimeout);
-  const intervalMs = getIntervalMs();
-  const now = Date.now();
-  const nextBoundary = now - (now % intervalMs) + intervalMs;
-  const delay = Math.max(nextBoundary - now, 5 * 1000);
-  refreshTimeout = setTimeout(async () => {
-    await reloadPrices();
-    scheduleNextRefresh();
-  }, delay);
-}
-
-function handleVisibilityChange() {
-  if (document.visibilityState === 'visible') {
-    runSmartSync('lt').finally(() => {
-      reloadPrices();
-      scheduleNextRefresh();
-    });
-  }
-}
-
-async function reloadPrices() {
-  try {
-    const data = await fetchPrices(date.value);
-    priceData.value = data.data?.lt || [];
-    // Debug: Log price breakdowns after prices are loaded and calculated
-    await nextTick();
-    logAllPriceBreakdowns();
-  } catch (error) {
-    priceData.value = [];
-  }
-}
-
-onMounted(() => {
-  reloadPrices();
-  scheduleNextRefresh();
-  unsubscribePrices = onPricesUpdated(() => {
-    reloadPrices();
-  });
-  document.addEventListener('visibilitychange', handleVisibilityChange);
-});
-
-onUnmounted(() => {
-  if (refreshTimeout) clearTimeout(refreshTimeout);
-  if (unsubscribePrices) unsubscribePrices();
-  document.removeEventListener('visibilitychange', handleVisibilityChange);
-});
-
-watch(date, () => {
-  reloadPrices();
-});
-
-function updateTodaySEO() {
-  const locale = i18n.global.locale.value || 'lt';
-  const meta = route.meta || {};
-  const title = meta.title?.[locale] || meta.title || 'Elektros kaina LT';
-  const description = meta.description?.[locale] || meta.description ||
-    (locale === 'lt'
-      ? 'Rodykite Nord Pool elektros kainas su visais taikomais mokesčiais ir prievolėmis. Kainos atnaujinamos automatiškai.'
-      : 'Display Nord Pool electricity prices with all applicable taxes and fees. Prices are updated automatically.');
-  const dateStr = moment(date.value).format('YYYY-MM-DD');
-  const path = `/today?date=${dateStr}`;
-
-  const extraStructuredData = [];
-  if (priceData.value.length > 0) {
-    const prices = priceData.value.map((entry) => parseFloat(calculatePrice(entry)));
-    const averagePrice = prices.reduce((sum, value) => sum + value, 0) / prices.length;
-    extraStructuredData.push(generatePriceDataStructuredData({
-      date: dateStr,
-      averagePrice,
-      minPrice: Math.min(...prices),
-      maxPrice: Math.max(...prices),
-    }));
-  }
-
-  setSEO({
-    title,
-    description,
-    url: path,
-    locale,
-    structuredData: buildRouteStructuredData({ ...route, fullPath: path, path: '/today' }, locale, extraStructuredData),
-  });
-}
-
-watch([priceData, date], () => {
-  updateTodaySEO();
-}, { deep: true });
-
-function setToday() {
-  date.value = new Date();
-}
-
-function setTomorrow() {
-  date.value = moment().add(1, 'days').toDate();
-}
-</script>
-
-<template>
-  <div class="container-fluid px-2 px-md-3">
-    <div class="today-page">
-      <div class="d-flex gap-2 mb-3">
-        <VueDatePicker v-model="date" locale="lt" month-name-format="long" format="yyyy-MM-dd" 
-          auto-apply reverse-years :enable-time-picker="false" 
-          :max-date="nextDay" :min-date="minDate" prevent-min-max-navigation 
-          class="flex-grow-1" />
-        <button @click="setToday" class="btn btn-secondary">{{ $t('home.today') }}</button>
-        <button @click="setTomorrow" class="btn btn-secondary">{{ $t('home.tomorrow') }}</button>
-      </div>
-
-      <PriceTable :priceData="priceData" />
-      
-    </div>
-  </div>
-</template>
-
-<style scoped>
-.today-page {
-  padding: 0;
-}
-
-/* Mobile: reduce container padding and ensure proper horizontal scrolling */
-@media (max-width: 767.98px) {
-  .container-fluid {
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
-  }
-}
-</style>
-
+<script setup>
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import moment from 'moment-timezone';
+import { fetchPrices, onPricesUpdated, runSmartSync } from '../services/priceService';
+import { calculatePrice, logAllPriceBreakdowns } from '../services/priceCalculationService';
+import PriceTable from '../components/PriceTable.vue';
+import i18n from '../i18n';
+import {
+  setSEO,
+  buildRouteStructuredData,
+  generatePriceDataStructuredData,
+} from '../utils/seo';
+import { DISPLAY_TIMEZONE } from '../utils/releaseWindow';
+
+moment.tz.setDefault(DISPLAY_TIMEZONE);
+
+const route = useRoute();
+
+function resolveInitialDate() {
+  const queryDate = route.query.date;
+  if (typeof queryDate === 'string' && moment.tz(queryDate, DISPLAY_TIMEZONE).isValid()) {
+    return moment.tz(queryDate, DISPLAY_TIMEZONE).startOf('day').toDate();
+  }
+  return moment().tz(DISPLAY_TIMEZONE).startOf('day').toDate();
+}
+
+const date = ref(resolveInitialDate());
+const minDate = moment.tz('2012-07-01', DISPLAY_TIMEZONE).startOf('day').toDate();
+const maxDate = moment().tz(DISPLAY_TIMEZONE).add(1, 'day').startOf('day').toDate();
+const priceData = ref([]);
+const isLoading = ref(true);
+const error = ref(null);
+
+let refreshTimeout = null;
+let unsubscribePrices = null;
+
+function getIntervalMs() {
+  if (priceData.value && priceData.value.length >= 2) {
+    const diffSec = priceData.value[1].timestamp - priceData.value[0].timestamp;
+    if (diffSec > 0) return diffSec * 1000;
+  }
+  return 60 * 60 * 1000; // default 1 hour
+}
+
+function scheduleNextRefresh() {
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+  const intervalMs = getIntervalMs();
+  const now = Date.now();
+  const nextBoundary = now - (now % intervalMs) + intervalMs;
+  const delay = Math.max(nextBoundary - now, 5 * 1000);
+  refreshTimeout = setTimeout(async () => {
+    await reloadPrices();
+    scheduleNextRefresh();
+  }, delay);
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === 'visible') {
+    runSmartSync('lt').finally(() => {
+      reloadPrices();
+      scheduleNextRefresh();
+    });
+  }
+}
+
+async function reloadPrices() {
+  try {
+    isLoading.value = true;
+    error.value = null;
+    const data = await fetchPrices(date.value);
+    priceData.value = data.data?.lt || [];
+    await nextTick();
+    logAllPriceBreakdowns();
+  } catch (err) {
+    error.value = err?.message || 'Failed to load prices';
+    priceData.value = [];
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+onMounted(() => {
+  reloadPrices();
+  scheduleNextRefresh();
+  unsubscribePrices = onPricesUpdated(() => {
+    reloadPrices();
+  });
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+});
+
+onUnmounted(() => {
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+  if (unsubscribePrices) unsubscribePrices();
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
+});
+
+watch(date, () => {
+  reloadPrices();
+});
+
+function updateTodaySEO() {
+  const locale = i18n.global.locale.value || 'lt';
+  const meta = route.meta || {};
+  const title = meta.title?.[locale] || meta.title || 'Elektros kaina LT';
+  const description = meta.description?.[locale] || meta.description ||
+    (locale === 'lt'
+      ? 'Rodykite Nord Pool elektros kainas su visais taikomais mokesčiais ir prievolėmis. Kainos atnaujinamos automatiškai.'
+      : 'Display Nord Pool electricity prices with all applicable taxes and fees. Prices are updated automatically.');
+  const dateStr = moment(date.value).tz(DISPLAY_TIMEZONE).format('YYYY-MM-DD');
+  const path = `/today?date=${dateStr}`;
+
+  const extraStructuredData = [];
+  if (priceData.value.length > 0) {
+    const prices = priceData.value.map((entry) => parseFloat(calculatePrice(entry)));
+    const averagePrice = prices.reduce((sum, value) => sum + value, 0) / prices.length;
+    extraStructuredData.push(generatePriceDataStructuredData({
+      date: dateStr,
+      averagePrice,
+      minPrice: Math.min(...prices),
+      maxPrice: Math.max(...prices),
+    }));
+  }
+
+  setSEO({
+    title,
+    description,
+    url: path,
+    locale,
+    structuredData: buildRouteStructuredData({ ...route, fullPath: path, path: '/today' }, locale, extraStructuredData),
+  });
+}
+
+watch([priceData, date], () => {
+  updateTodaySEO();
+}, { deep: true });
+
+function setToday() {
+  date.value = moment().tz(DISPLAY_TIMEZONE).startOf('day').toDate();
+}
+
+function setTomorrow() {
+  date.value = moment().tz(DISPLAY_TIMEZONE).add(1, 'day').startOf('day').toDate();
+}
+</script>
+
+<template>
+  <div class="container-fluid px-2 px-md-3">
+    <div class="today-page">
+      <div class="d-flex gap-2 mb-3">
+        <VueDatePicker v-model="date" locale="lt" month-name-format="long" format="yyyy-MM-dd"
+          auto-apply reverse-years :enable-time-picker="false"
+          :max-date="maxDate" :min-date="minDate" prevent-min-max-navigation
+          class="flex-grow-1" />
+        <button @click="setToday" class="btn btn-secondary">{{ $t('home.today') }}</button>
+        <button @click="setTomorrow" class="btn btn-secondary">{{ $t('home.tomorrow') }}</button>
+      </div>
+
+      <div v-if="isLoading" class="alert alert-info">
+        {{ $t('upcoming.loading') }}
+      </div>
+      <div v-else-if="error" class="alert alert-danger">
+        {{ $t('upcoming.error') }}
+      </div>
+      <PriceTable v-else :priceData="priceData" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-page {
+  padding: 0;
+}
+
+/* Mobile: reduce container padding and ensure proper horizontal scrolling */
+@media (max-width: 767.98px) {
+  .container-fluid {
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+}
+</style>
+

--- a/electricity-prices-build/tests/views.smoke.test.js
+++ b/electricity-prices-build/tests/views.smoke.test.js
@@ -34,6 +34,7 @@ vi.mock('vue-router', () => ({
     },
     path: '/today',
     fullPath: '/today',
+    query: {},
   }),
 }));
 


### PR DESCRIPTION
## Summary
- Bootstrap `/upcoming` on fresh DB: when the API returns 404 `NO_DATA_FOUND`, fetch today and tomorrow via `/nps/prices?date=` (Elering-backed), then retry upcoming or return cached bootstrap data.
- Repair Today page: use Date objects for date picker min/max, initialize from `?date=` query in Europe/Vilnius, add loading/error states.
- Hide PriceTable (including misleading `0.000` average) when fewer than three price rows are available.

Fixes #100

## Test plan
- [x] `npm test --prefix electricity-prices-build` (24 passed)
- [x] `npm run build --prefix electricity-prices-build`
- [ ] Fresh DB: open `/upcoming` — prices load or empty-state instead of error toast
- [ ] Open `/today` — date picker shows today, prices or no-data message (not 0.000 average)
- [ ] `/today?date=YYYY-MM-DD` selects the requested date

Made with [Cursor](https://cursor.com)