### PR TITLE
fix(docs): pin Swagger UI and /docs alias (Refs #101)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage/
 !**/*.env.example
 deploy/local.env
 deploy/local.override.env
+docker-compose.dev.local.yml
 
 # IDE and editor history
 .history/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ cp .env.example .env.development
 # Start in development mode (exposed services for debugging)
 ./scripts/dev.sh
 
+# Optional: when host ports 3000/5432 are in use, copy and edit local overrides
+# cp docker-compose.dev.local.example docker-compose.dev.local.yml
+# dev.sh auto-includes docker-compose.dev.local.yml when that file exists
+
 # Or manually:
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file .env.development up -d --build
 ```
@@ -55,13 +59,13 @@ docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file .env.d
 - **Frontend**: http://localhost:80 (Nginx with API proxy)
 - **Backend**: Internal only (accessed via frontend proxy)
 - **Database**: Internal only
-- **Swagger UI**: http://localhost:80/api/ (API documentation)
+- **Swagger UI**: http://localhost:80/api/ (API documentation; alias `/docs`)
 
 #### **Development Mode**
 - **Frontend**: http://localhost:5173 (Vite dev server)
 - **Backend**: http://localhost:3000 (Express with hot-reload)
 - **Database**: localhost:5432
-- **Swagger UI**: http://localhost:5173/api/ (API documentation)
+- **Swagger UI**: http://localhost:5173/api/ (alias `/docs`)
 
 #### **CapRover Deployment**
 - **Frontend**: https://your-app-name.your-domain.com
@@ -427,8 +431,8 @@ Contributions require DCO sign-off; see [CONTRIBUTING.md](./CONTRIBUTING.md). Ci
 - [Coolify deployment](./COOLIFY_DEPLOYMENT.md) — production deploy guide
 - [Coolify password rotation](./docs/ops/coolify-password-rotation.md) — operator runbook (#34)
 - [Project Planning](./documentation/project_planning.md) - Detailed project documentation
-- [API Documentation](./electricity-prices-build/public/docs/swagger.yaml) - Swagger API specs
-- [Interactive API Docs](./api/) - Swagger UI interface
+- [API Documentation](./swagger-ui/openapi.yaml) - OpenAPI spec (source of truth)
+- [Interactive API Docs](./swagger-ui/README.md) - Swagger UI at `/api/` or `/docs`
 
 ## 🏆 **Migration Success**
 

--- a/docker-compose.coolify-oneclick.yml
+++ b/docker-compose.coolify-oneclick.yml
@@ -90,7 +90,7 @@ services:
 
   # Swagger UI service
   swagger-ui:
-    image: swaggerapi/swagger-ui:latest
+    image: swaggerapi/swagger-ui:v5.11.0
     container_name: electricity_swagger_ui
     environment:
       # Swagger UI configurator looks for SWAGGER_JSON_URL to set the default spec URL

--- a/docker-compose.dev.local.example
+++ b/docker-compose.dev.local.example
@@ -1,0 +1,9 @@
+# Optional local port overrides (gitignored copy: docker-compose.dev.local.yml).
+# scripts/dev.sh auto-includes docker-compose.dev.local.yml when present.
+services:
+  backend:
+    ports: !override
+      - "3003:3000"
+  db:
+    ports: !override
+      - "5433:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
 
   # Swagger UI service for API documentation (internal only)
   swagger-ui:
-    image: swaggerapi/swagger-ui:latest
+    image: swaggerapi/swagger-ui:v5.11.0
     container_name: electricity_swagger_ui
     environment:
       # Swagger UI configurator looks for SWAGGER_JSON_URL to set the default spec URL

--- a/electricity-prices-build/README.md
+++ b/electricity-prices-build/README.md
@@ -112,7 +112,7 @@ server: {
       secure: false
     },
     '/api': {
-      target: 'http://swagger-ui:8080/swagger',
+      target: 'http://swagger-ui:8080',
       changeOrigin: true,
       secure: false
     }

--- a/electricity-prices-build/nginx.conf
+++ b/electricity-prices-build/nginx.conf
@@ -34,6 +34,14 @@ http {
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
         add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'" always;
 
+        # Friendly alias for API docs (flows UA3 / adresses pattern)
+        location = /docs {
+            return 302 /api/;
+        }
+        location = /docs/ {
+            return 302 /api/;
+        }
+
         # API endpoints at /api/v1 (backend) - must come before /api/ to avoid conflicts
         location /api/v1/ {
             proxy_pass http://backend:3000;

--- a/electricity-prices-build/vite.config.js
+++ b/electricity-prices-build/vite.config.js
@@ -7,6 +7,22 @@ import { sitemapPlugin } from './vite-plugin-sitemap.js'
 // Read package.json to get homepage
 const packageJson = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
 
+function docsRedirectPlugin() {
+  return {
+    name: 'docs-redirect',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url === '/docs' || req.url === '/docs/') {
+          res.writeHead(302, { Location: '/api/' })
+          res.end()
+          return
+        }
+        next()
+      })
+    },
+  }
+}
+
 function googleSiteVerificationPlugin(verificationCode) {
   return {
     name: 'google-site-verification',
@@ -32,6 +48,7 @@ export default defineConfig(({ mode }) => {
     vue(),
     sitemapPlugin(),
     googleSiteVerificationPlugin(googleVerification),
+    docsRedirectPlugin(),
   ],
   define: {
     // Inject homepage from package.json as environment variable

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -25,8 +25,14 @@ sync_postgres_password_between_files "$ENV_FILE" "$LOCAL_ENV_FILE" || true
 
 cp "$ENV_FILE" .env
 
+COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.dev.yml)
+if [ -f docker-compose.dev.local.yml ]; then
+  COMPOSE_FILES+=(-f docker-compose.dev.local.yml)
+  echo "Including docker-compose.dev.local.yml (local port overrides)."
+fi
+
 # Build and start services with development override
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file "$ENV_FILE" up -d --build
+docker-compose "${COMPOSE_FILES[@]}" --env-file "$ENV_FILE" up -d --build
 
 echo "✅ Development environment started!"
 echo ""
@@ -40,8 +46,12 @@ echo "  - Frontend (Vue.js + Vite)"
 echo "  - Backend (Express + nodemon)"
 echo "  - Data Sync (nodemon)"
 echo ""
+COMPOSE_HINT="docker-compose -f docker-compose.yml -f docker-compose.dev.yml"
+if [ -f docker-compose.dev.local.yml ]; then
+  COMPOSE_HINT="${COMPOSE_HINT} -f docker-compose.dev.local.yml"
+fi
 echo "📊 View logs:"
-echo "  docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f"
+echo "  ${COMPOSE_HINT} logs -f"
 echo ""
 echo "🛑 Stop services:"
-echo "  docker-compose -f docker-compose.yml -f docker-compose.dev.yml down" 
+echo "  ${COMPOSE_HINT} down" 

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -14,3 +14,5 @@ CI runs `node bin/openapi-json-from-yaml.js --check` and fails if JSON drifts.
 ## What production serves
 
 Swagger UI loads **`/api/openapi.yaml`** (`SWAGGER_JSON_URL` in `docker-compose.yml` and Coolify compose). Both YAML and JSON are mounted under nginx (`electricity-prices-build/nginx.conf`); clients that request JSON get the derived file. Keep JSON in sync so direct `/api/openapi.json` requests match YAML.
+
+Interactive docs: **`/api/`** (canonical). **`/docs`** redirects to `/api/` in nginx and Vite dev. Image pin: `swaggerapi/swagger-ui:v5.11.0`.


### PR DESCRIPTION
## Summary

Quick-win subset of #101 (UA3 OpenAPI + docs UX):

- Pin `swaggerapi/swagger-ui:v5.11.0` in base and Coolify compose (was `:latest`)
- Add `/docs` → `/api/` redirect in nginx and Vite dev server
- `scripts/dev.sh` auto-includes `docker-compose.dev.local.yml` when present; add `docker-compose.dev.local.example`
- Fix stale README doc links; correct frontend README proxy target
- Gitignore untracked `docker-compose.dev.local.yml`

## Deferred to full UA3 (#101)

- Spectral lint in CI
- Expanded contract/sample endpoint tests
- Express-embedded Swagger at `/docs`
- Remove duplicate/stale OpenAPI copies under frontend public paths
- Required CI gate for contract tests

## Test plan

- [x] `POSTGRES_PASSWORD=test docker compose config -q`
- [x] `POSTGRES_PASSWORD=test docker compose -f docker-compose.yml -f docker-compose.dev.yml config -q`
- [x] `POSTGRES_PASSWORD=test docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dev.local.example config -q`
- [x] `node bin/openapi-json-from-yaml.js`
- [x] `node bin/validate-openapi-routes.js`

Refs #101

Made with [Cursor](https://cursor.com)