### PR TITLE
fix(frontend): allow today fetch and refetch incomplete cache days

### DIFF
--- a/electricity-prices-build/src/services/priceCacheService.js
+++ b/electricity-prices-build/src/services/priceCacheService.js
@@ -232,9 +232,6 @@ export function getDaysNeedingSync(country = 'lt', now = moment()) {
   }
 
   return candidates.filter((dateStr) => {
-    if (isDaySynced(country, dateStr)) {
-      return false;
-    }
     const validation = validateDayCompleteness(dateStr, country);
     return !validation.isComplete;
   });

--- a/electricity-prices-build/src/utils/releaseWindow.js
+++ b/electricity-prices-build/src/utils/releaseWindow.js
@@ -105,12 +105,27 @@ export function getSyncPollIntervalMs(now = moment()) {
 }
 
 /**
+ * Whether the requested date is the current calendar day in Vilnius.
+ * @param {Date|string|import('moment').Moment} date
+ * @param {import('moment').Moment} [now]
+ */
+export function isCurrentDisplayDay(date, now = moment()) {
+  const nowVilnius = now.clone().tz(DISPLAY_TIMEZONE);
+  return moment(date).tz(DISPLAY_TIMEZONE).isSame(nowVilnius, 'day');
+}
+
+/**
  * Whether a network fetch for today/future data is allowed in the current phase.
  * Historical dates are always allowed via {@link isHistoricalDate}.
+ * Today's prices were published in a prior release window and are always fetchable.
  * @param {Date|string|import('moment').Moment} date
  * @param {import('moment').Moment} [now]
  */
 export function shouldFetchFutureData(date, now = moment()) {
+  if (isCurrentDisplayDay(date, now)) {
+    return true;
+  }
+
   const phase = getReleasePhase(now);
   if (phase === RELEASE_PHASE.DURING) {
     return true;

--- a/electricity-prices-build/tests/releaseWindow.test.js
+++ b/electricity-prices-build/tests/releaseWindow.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import moment from 'moment-timezone';
+import {
+  shouldFetchFutureData,
+  isCurrentDisplayDay,
+  getTargetReleaseDay,
+  DISPLAY_TIMEZONE,
+} from '../src/utils/releaseWindow.js';
+
+describe('shouldFetchFutureData', () => {
+  it('allows fetching the current Vilnius calendar day in every phase', () => {
+    const now = moment.tz('2026-06-16 00:30', DISPLAY_TIMEZONE);
+    const today = now.clone().startOf('day').toDate();
+
+    expect(isCurrentDisplayDay(today, now)).toBe(true);
+    expect(shouldFetchFutureData(today, now)).toBe(true);
+  });
+
+  it('allows tomorrow only after release window on the target day', () => {
+    const now = moment.tz('2026-06-16 00:30', DISPLAY_TIMEZONE);
+    const tomorrow = now.clone().add(1, 'day').startOf('day').toDate();
+    const targetDay = getTargetReleaseDay(now);
+
+    expect(moment(tomorrow).tz(DISPLAY_TIMEZONE).format('YYYY-MM-DD')).toBe(targetDay);
+    expect(shouldFetchFutureData(tomorrow, now)).toBe(true);
+  });
+
+  it('blocks day-after-tomorrow before release window', () => {
+    const now = moment.tz('2026-06-16 00:30', DISPLAY_TIMEZONE);
+    const dayAfterTomorrow = now.clone().add(2, 'day').startOf('day').toDate();
+
+    expect(shouldFetchFutureData(dayAfterTomorrow, now)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **`shouldFetchFutureData()`** — today's Vilnius calendar day is always fetchable in every release phase (prices were published in a prior window).
- **`getDaysNeedingSync()`** — refetch when cache completeness fails, ignoring stale `isDaySynced` localStorage markers after DB reset.
- **Tests** — add `tests/releaseWindow.test.js` covering today/tomorrow/day-after-tomorrow fetch rules.

PR #102 already merged TodayView bootstrap/datepicker fixes; this PR includes only the release-window and cache-sync scope from #104.

Fixes #104

## Test plan

- [x] `npm test --prefix electricity-prices-build` (24 tests, including 3 new releaseWindow cases)
- [x] `npm run build --prefix electricity-prices-build`
- [ ] After merge: open `/today` with fresh or volume-reset DB — prices or honest no-data, not empty skippedNetwork state


Made with [Cursor](https://cursor.com)