### PR TITLE
fix(backend): guard /health when Postgres is unavailable

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import dotenv from 'dotenv';
 import moment from 'moment-timezone';
 import { getDatabaseStats, getSystemHealth } from './database.js';
+import { buildHealthResponse } from './lib/healthResponse.js';
 import v1Router from './v1.js';
 import { legacyApiShim } from './legacyApi.js';
 import { startSyncWorker, stopSyncWorker, getSyncStatus } from './syncWorker.js';
@@ -48,55 +49,12 @@ app.get('/health', async (req, res) => {
     const health = await getSystemHealth();
     const stats = await getDatabaseStats();
     const syncStatus = getSyncStatus();
-
-    const response = {
-      success: true,
-      timestamp: new Date().toISOString(),
-      system: {
-        ...health.system,
-        uptime: `${Math.floor(health.system.uptime / 3600)} hours`,
-      },
-      database: {
-        ...health.database,
-        stats: {
-          totalRecords: stats.totalRecords,
-          countries: stats.countries,
-          databaseSize: stats.databaseSize,
-          tableSizes: stats.tableSizes,
-        },
-      },
-      sync: {
-        ...health.sync,
-        worker: syncStatus,
-        recentActivity: stats.recentSyncs,
-        statistics: stats.syncStats,
-      },
-      scheduledJobs: syncStatus.scheduledJobs,
-      dataFreshness: health.sync.dataFreshness,
-    };
-
-    const isHealthy = health.database.connected
-      && health.sync.dataFreshness.every((country) => country.isRecent)
-      && syncStatus.isRunning;
-
-    response.overallStatus = isHealthy ? 'healthy' : 'degraded';
-    response.issues = [];
-
-    if (!health.database.connected) {
-      response.issues.push('Database connection failed');
-    }
-
-    const staleData = health.sync.dataFreshness.filter((country) => !country.isRecent);
-    if (staleData.length > 0) {
-      response.issues.push(
-        `Stale data detected: ${staleData.map((c) => `${c.country.toUpperCase()} (${c.hoursOld}h old)`).join(', ')}`,
-      );
-    }
-
-    if (!syncStatus.isRunning) {
-      response.issues.push('Sync worker not running');
-    }
-
+    const response = buildHealthResponse({
+      health,
+      stats,
+      syncStatus,
+      requireSyncWorker: true,
+    });
     res.status(200).json(response);
   } catch (error) {
     console.error('Error getting health status:', error);
@@ -106,6 +64,7 @@ app.get('/health', async (req, res) => {
       details: error.message,
       timestamp: new Date().toISOString(),
       overallStatus: 'degraded',
+      issues: ['Failed to get health status'],
     });
   }
 });

--- a/backend/src/lib/healthResponse.js
+++ b/backend/src/lib/healthResponse.js
@@ -1,0 +1,135 @@
+function hasHealthError(health) {
+  return !health || typeof health !== 'object' || typeof health.error === 'string';
+}
+
+function safeSystemSection(system) {
+  if (!system || typeof system !== 'object') {
+    return { uptime: 'unknown' };
+  }
+  const uptimeHours = typeof system.uptime === 'number'
+    ? `${Math.floor(system.uptime / 3600)} hours`
+    : 'unknown';
+  return { ...system, uptime: uptimeHours };
+}
+
+function safeDatabaseSection(database, stats) {
+  const section = database && typeof database === 'object' ? { ...database } : { connected: false };
+  if (!stats || typeof stats !== 'object' || typeof stats.error === 'string') {
+    return section;
+  }
+  return {
+    ...section,
+    stats: {
+      totalRecords: stats.totalRecords,
+      countries: stats.countries,
+      databaseSize: stats.databaseSize,
+      tableSizes: stats.tableSizes,
+    },
+  };
+}
+
+function safeSyncSection(sync, syncStatus, stats, extras = {}) {
+  const section = sync && typeof sync === 'object' ? { ...sync } : {};
+  const dataFreshness = Array.isArray(section.dataFreshness) ? section.dataFreshness : [];
+
+  return {
+    ...section,
+    dataFreshness,
+    worker: syncStatus ?? null,
+    recentActivity: stats && !stats.error ? stats.recentSyncs : [],
+    statistics: stats && !stats.error ? stats.syncStats : [],
+    ...extras,
+  };
+}
+
+function collectIssues({
+  health,
+  syncStatus,
+  requireSyncWorker = false,
+  isInActivePeriod = true,
+}) {
+  const issues = [];
+  const database = health?.database;
+  const dataFreshness = Array.isArray(health?.sync?.dataFreshness) ? health.sync.dataFreshness : [];
+
+  if (typeof health?.error === 'string') {
+    issues.push(`System health unavailable: ${health.error}`);
+  }
+
+  if (!database?.connected) {
+    issues.push('Database connection failed');
+  }
+
+  const staleData = dataFreshness.filter((country) => !country.isRecent);
+  if (staleData.length > 0) {
+    issues.push(
+      `Stale data detected: ${staleData.map((c) => `${c.country.toUpperCase()} (${c.hoursOld}h old)`).join(', ')}`,
+    );
+  }
+
+  if (requireSyncWorker && !syncStatus?.isRunning) {
+    issues.push('Sync worker not running');
+  } else if (!requireSyncWorker && !syncStatus?.isRunning && isInActivePeriod) {
+    issues.push('Sync worker not running');
+  }
+
+  return issues;
+}
+
+export function buildHealthResponse({
+  health,
+  stats,
+  syncStatus,
+  requireSyncWorker = false,
+  isInActivePeriod = true,
+  syncExtras = {},
+}) {
+  const timestamp = new Date().toISOString();
+
+  if (hasHealthError(health)) {
+    const issues = collectIssues({
+      health: health ?? { error: 'Unknown health status' },
+      syncStatus,
+      requireSyncWorker,
+      isInActivePeriod,
+    });
+    return {
+      success: false,
+      timestamp,
+      overallStatus: 'degraded',
+      issues,
+      error: health?.error ?? 'Failed to get health status',
+      system: safeSystemSection(null),
+      database: safeDatabaseSection(null, stats),
+      sync: safeSyncSection(null, syncStatus, stats, syncExtras),
+      scheduledJobs: syncStatus?.scheduledJobs ?? null,
+      dataFreshness: [],
+    };
+  }
+
+  const database = health.database ?? {};
+  const sync = health.sync ?? {};
+  const dataFreshness = Array.isArray(sync.dataFreshness) ? sync.dataFreshness : [];
+  const isHealthy = database.connected === true
+    && dataFreshness.every((country) => country.isRecent)
+    && (!requireSyncWorker || syncStatus?.isRunning === true);
+
+  const response = {
+    success: true,
+    timestamp,
+    system: safeSystemSection(health.system),
+    database: safeDatabaseSection(database, stats),
+    sync: safeSyncSection(sync, syncStatus, stats, syncExtras),
+    scheduledJobs: syncStatus?.scheduledJobs ?? null,
+    dataFreshness,
+    overallStatus: isHealthy ? 'healthy' : 'degraded',
+    issues: collectIssues({
+      health,
+      syncStatus,
+      requireSyncWorker,
+      isInActivePeriod,
+    }),
+  };
+
+  return response;
+}

--- a/backend/src/test.js
+++ b/backend/src/test.js
@@ -25,6 +25,7 @@ import {
 } from './lib/prices/backupFetchPolicy.js';
 import { hashManageToken, createManageToken } from './push/tokens.js';
 import { getVapidConfig, isPushConfigured } from './push/vapid.js';
+import { buildHealthResponse } from './lib/healthResponse.js';
 
 let passed = 0;
 let failed = 0;
@@ -228,6 +229,31 @@ test('isPushConfigured is false without VAPID env', () => {
 test('getVapidConfig defaults subject', () => {
   const config = getVapidConfig();
   assert.equal(config.subject, 'mailto:ops@example.com');
+});
+
+test('buildHealthResponse returns degraded when system health reports error', () => {
+  const response = buildHealthResponse({
+    health: { error: 'ECONNREFUSED' },
+    stats: { error: 'ECONNREFUSED' },
+    syncStatus: { isRunning: false, scheduledJobs: null },
+  });
+  assert.equal(response.overallStatus, 'degraded');
+  assert.equal(response.success, false);
+  assert.equal(response.system.uptime, 'unknown');
+  assert.ok(response.issues.some((issue) => issue.includes('ECONNREFUSED')));
+  assert.ok(response.issues.some((issue) => issue.includes('Database connection failed')));
+});
+
+test('buildHealthResponse guards missing nested health fields', () => {
+  const response = buildHealthResponse({
+    health: { database: { connected: false }, sync: {}, system: {} },
+    stats: { error: 'unavailable' },
+    syncStatus: { isRunning: true, scheduledJobs: [] },
+  });
+  assert.equal(response.overallStatus, 'degraded');
+  assert.equal(response.success, true);
+  assert.deepEqual(response.dataFreshness, []);
+  assert.ok(response.issues.includes('Database connection failed'));
 });
 
 console.log(`\nTest results: ${passed} passed, ${failed} failed`);

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -19,6 +19,7 @@ import {
   updateCronSchedule,
 } from './lib/admin/cronSchedules.js';
 import { getPriceData, getPriceDataAll, getLatestPrice, getCurrentPrice, getAvailableCountries, getSettings, updateSetting, getCurrentHourPrice, getLatestPriceAll, getCurrentHourPriceAll, getLatestTimestamp, logSync, getAllEarliestTimestamps, getInitialSyncStatus, getDatabaseStats, getSystemHealth, getAllCountrySyncStatus } from './database.js';
+import { buildHealthResponse } from './lib/healthResponse.js';
 import pool from './database.js';
 import { createPushRouter } from './push/router.js';
 import { createPushAdminRouter } from './push/adminRouter.js';
@@ -1007,65 +1008,27 @@ router.get('/health', async (req, res) => {
     const stats = await getDatabaseStats();
     const syncStatus = syncWorker.getStatus();
     const countrySyncStatus = await getAllCountrySyncStatus();
-    
-    const response = {
-      success: true,
-      timestamp: new Date().toISOString(),
-      system: {
-        ...health.system,
-        uptime: Math.floor(health.system.uptime / 3600) + ' hours'
-      },
-      database: {
-        ...health.database,
-        stats: {
-          totalRecords: stats.totalRecords,
-          countries: stats.countries,
-          databaseSize: stats.databaseSize,
-          tableSizes: stats.tableSizes
-        }
-      },
-      sync: {
-        ...health.sync,
-        worker: syncStatus,
-        recentActivity: stats.recentSyncs,
-        statistics: stats.syncStats,
-        countrySyncStatus: countrySyncStatus
-      },
-      scheduledJobs: syncStatus.scheduledJobs,
-      dataFreshness: health.sync.dataFreshness
-    };
-    
     const isInActivePeriod = isInReleaseWindow();
-    
-    // Add overall health status
-    const isHealthy = health.database.connected && 
-                     health.sync.dataFreshness.every(country => country.isRecent);
-    
-    response.overallStatus = isHealthy ? 'healthy' : 'degraded';
-    response.issues = [];
-    
-    if (!health.database.connected) {
-      response.issues.push('Database connection failed');
-    }
-    
-    const staleData = health.sync.dataFreshness.filter(country => !country.isRecent);
-    if (staleData.length > 0) {
-      response.issues.push(`Stale data detected: ${staleData.map(c => `${c.country.toUpperCase()} (${c.hoursOld}h old)`).join(', ')}`);
-    }
-    
-    // Only report sync worker issues during active period
-    if (!syncStatus.isRunning && isInActivePeriod) {
-      response.issues.push('Sync worker not running');
-    }
-    
-    res.json(response);
+
+    const response = buildHealthResponse({
+      health,
+      stats,
+      syncStatus,
+      requireSyncWorker: false,
+      isInActivePeriod,
+      syncExtras: { countrySyncStatus },
+    });
+
+    res.status(200).json(response);
   } catch (error) {
     console.error('Error getting health status:', error);
-    res.status(500).json({
+    res.status(200).json({
       success: false,
       error: 'Failed to get health status',
       details: error.message,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      overallStatus: 'degraded',
+      issues: ['Failed to get health status'],
     });
   }
 });


### PR DESCRIPTION
## Summary
- Add shared `buildHealthResponse` helper that guards `health.system`, `health.database`, and `health.sync` before spreading nested fields
- `/health` and `/api/v1/health` return `overallStatus: degraded` with explicit `issues` when Postgres is temporarily unavailable (no 500 or property access crash)
- Add backend unit tests for the error and missing-nested-fields paths

Fixes #105

## Test plan
- [x] `npm test --prefix backend`
- [x] `npm run build --prefix electricity-prices-build`
- [ ] `curl /health` during fresh-volume startup returns JSON degraded, not 500

Made with [Cursor](https://cursor.com)