### PR TITLE
docs(dev): steer empty DB to LFS restore or initial sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ cp .env.example .env.development
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml --env-file .env.development up -d --build
 ```
 
+#### **Empty database (fresh volume)**
+A new Postgres volume triggers **historical initial sync** from 2012 (can take hours). Until recent rows exist, `/api/v1/nps/prices/upcoming` returns 404 and `/health` may report **degraded** status.
+
+**Fast path (< 5 min):** restore the LFS backup after the stack is up:
+```bash
+./bin/restore-db-lfs.sh --fresh-volume   # uses data/db-backup/*.sql.gz
+```
+See [docs/ops/db-backup-lfs.md](./docs/ops/db-backup-lfs.md) and [docs/ops/backup-restore.md](./docs/ops/backup-restore.md).
+
+**Alternative:** wait for initial sync to complete. Track progress via `GET /api/v1/sync/status` (`initialSync` fields) or backend logs.
+
+**CI-sized fixture:** [database/fixtures/ci_seed.sql](./database/fixtures/ci_seed.sql) for integration tests and golden harness (not a full historical dataset).
+
 #### **CapRover Deployment (Cloud)**
 ```bash
 # Prepare for CapRover deployment

--- a/bin/smoke-local.sh
+++ b/bin/smoke-local.sh
@@ -42,6 +42,7 @@ if curl -sf "${API_URL}/health" >/dev/null 2>&1; then
   echo "==> GET /health OK"
   curl -sf "${API_URL}/health" | head -c 200 || true
   echo ""
+  echo "    (degraded during initial sync or before Postgres is ready is expected)"
 
   echo "==> GET /api/v1/sync/status OK"
   curl -sf "${API_URL}/api/v1/sync/status" | head -c 200 || true

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -36,6 +36,12 @@ docker-compose "${COMPOSE_FILES[@]}" --env-file "$ENV_FILE" up -d --build
 
 echo "✅ Development environment started!"
 echo ""
+echo "📦 Database data:"
+echo "  Empty volume → historical initial sync (hours) OR restore LFS backup:"
+echo "    ./bin/restore-db-lfs.sh --fresh-volume"
+echo "  Docs: docs/ops/db-backup-lfs.md | CI fixture: database/fixtures/ci_seed.sql"
+echo "  /health may show degraded until Postgres is ready or data exists."
+echo ""
 echo "📱 Services:"
 echo "  Frontend: http://localhost:5173 (Vite dev server)"
 echo "  Backend:  http://localhost:3000 (Express with nodemon)"


### PR DESCRIPTION
## Summary
- README dev section explains empty-volume behavior and `./bin/restore-db-lfs.sh --fresh-volume` fast path
- `scripts/dev.sh` prints restore links and notes degraded `/health` during startup
- `bin/smoke-local.sh` documents expected degraded health during initial sync

Fixes #106

## Test plan
- [x] Docs only; no runtime code changes
- [ ] New developer can follow README to restore LFS backup in < 5 min

Made with [Cursor](https://cursor.com)