### PR TITLE
feat(openapi): Spectral baseline lint in CI (UA3 quick-win)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: OpenAPI route parity check
         run: node bin/validate-openapi-routes.js
 
+      - name: OpenAPI Spectral lint (UA3 baseline)
+        run: npx --yes @stoplight/spectral-cli@6.15.0 lint swagger-ui/openapi.yaml
+
       - name: Warn if vendor/flows is behind origin/main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,21 @@
+rules:
+  openapi-version:
+    description: OpenAPI version must be 3.x
+    given: $
+    then:
+      field: openapi
+      function: pattern
+      functionOptions:
+        match: ^3\.
+  info-version-present:
+    description: info.version is required
+    given: $.info
+    then:
+      field: version
+      function: truthy
+  paths-defined:
+    description: paths object must be defined
+    given: $
+    then:
+      field: paths
+      function: truthy

--- a/documentation/API.md
+++ b/documentation/API.md
@@ -4,7 +4,9 @@
 
 The Electricity Prices NordPool API provides access to electricity price data for Baltic countries (Lithuania, Estonia, Latvia, Finland) with comprehensive sync management capabilities.
 
-**OpenAPI source of truth:** `swagger-ui/openapi.yaml` (JSON generated in CI). Interactive docs: `/api/` via the frontend proxy.
+**OpenAPI source of truth:** `swagger-ui/openapi.yaml` (JSON generated in CI). Interactive docs: `/api/` via the frontend proxy (`/docs` redirects to `/api/` in nginx and Vite dev).
+
+**Contract lint:** CI runs Spectral baseline rules (`.spectral.yaml`); expand toward full `spectral:oas` in UA3 follow-ups.
 
 **Legacy compatibility:** Unversioned `/api/*` paths forward to `/api/v1/*` with deprecation headers. See [legacy-api.md](./legacy-api.md).
 

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -2,6 +2,8 @@
 
 **Source of truth:** `openapi.yaml`. Edit YAML only.
 
+**Lint:** CI runs Spectral baseline rules (`.spectral.yaml`). Full `spectral:oas` extend is tracked in #101.
+
 **Derived copy:** `openapi.json` is generated from YAML. Regenerate after YAML changes:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.spectral.yaml` baseline OpenAPI rules (version, info.version, paths)
- Run Spectral in CI (`lint-and-unit` job) against `swagger-ui/openapi.yaml`
- Document `/docs` alias and lint policy in `documentation/API.md` and `swagger-ui/README.md`

Refs #101 (full UA3: extend to `spectral:oas`, contract golden tests, embedded `/docs` remain open; spectral:oas crash tracked in #122)

## Test plan
- [x] `npm test --prefix backend`
- [x] `npm run build --prefix electricity-prices-build`
- [x] `npx @stoplight/spectral-cli@6.15.0 lint swagger-ui/openapi.yaml`
- [x] `node bin/openapi-json-from-yaml.js --check`
- [x] `node bin/validate-openapi-routes.js`

Made with [Cursor](https://cursor.com)