### PR TITLE
test(e2e): expand smoke coverage for core views and legacy API

### DIFF
--- a/bin/run-e2e.sh
+++ b/bin/run-e2e.sh
@@ -24,7 +24,21 @@ echo "==> ensuring Playwright browser: ${E2E_BROWSERS}"
 npx playwright install "${E2E_BROWSERS}"
 
 export FRONTEND_URL="${FRONTEND_URL:-${LOCAL_FRONTEND_URL:-http://127.0.0.1:5173}}"
-export API_URL="${API_URL:-${LOCAL_API_URL:-http://127.0.0.1:3000}}"
+
+resolve_api_url() {
+  local candidate url
+  for candidate in "${API_URL:-}" "${LOCAL_API_URL:-}" "http://127.0.0.1:3000" "http://127.0.0.1:3003"; do
+    [[ -z "${candidate}" ]] && continue
+    url="${candidate%/}"
+    if curl -sf "${url}/health" >/dev/null 2>&1; then
+      echo "${url}"
+      return 0
+    fi
+  done
+  echo "${API_URL:-${LOCAL_API_URL:-http://127.0.0.1:3000}}"
+}
+
+export API_URL="$(resolve_api_url)"
 export SKIP_WEB_SERVER="${SKIP_WEB_SERVER:-1}"
 echo "==> Playwright E2E at ${FRONTEND_URL} (API ${API_URL}, SKIP_WEB_SERVER=${SKIP_WEB_SERVER})"
 npm test

--- a/tests/e2e/api.spec.js
+++ b/tests/e2e/api.spec.js
@@ -1,15 +1,21 @@
 import { test, expect } from '@playwright/test';
+import { expectLegacyDeprecationHeaders, resolveApiBase } from './helpers/apiBase.js';
 
-const apiBase = process.env.API_URL || 'http://127.0.0.1:3000';
+const apiBase = resolveApiBase();
 
 test.describe('API contracts', () => {
   test('legacy sync status includes Deprecation header', async ({ request }) => {
     const response = await request.get(`${apiBase}/api/sync/status`);
     expect(response.ok()).toBeTruthy();
+    expectLegacyDeprecationHeaders(response.headers(), '/api/v1/sync/status');
+  });
+
+  test('legacy nps prices includes Deprecation header', async ({ request }) => {
+    const response = await request.get(`${apiBase}/api/nps/prices?country=lt&date=2024-06-15`);
+    expect(response.ok()).toBeTruthy();
     const headers = response.headers();
-    expect(headers.deprecation).toBe('true');
-    expect(headers.link).toMatch(/successor-version/);
-    expect(headers.link).toMatch(/\/api\/v1\/sync\/status/);
+    expectLegacyDeprecationHeaders(headers, '/api/v1/nps/prices');
+    expect(headers.link).toMatch(/country=lt/);
   });
 
   test('v1 health responds OK', async ({ request }) => {
@@ -18,5 +24,12 @@ test.describe('API contracts', () => {
     const body = await response.json();
     expect(body.success).toBe(true);
     expect(body.overallStatus).toBeTruthy();
+  });
+
+  test('v1 sync status has no Deprecation header', async ({ request }) => {
+    const response = await request.get(`${apiBase}/api/v1/sync/status`);
+    expect(response.ok()).toBeTruthy();
+    const headers = response.headers();
+    expect(headers.deprecation).toBeUndefined();
   });
 });

--- a/tests/e2e/helpers/apiBase.js
+++ b/tests/e2e/helpers/apiBase.js
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+
+/**
+ * Resolve a reachable backend base URL for direct API contract tests.
+ * Legacy /api/* routes MUST hit the backend (not the Vite/nginx swagger proxy).
+ */
+export function resolveApiBase() {
+  if (process.env.API_URL) {
+    return process.env.API_URL.replace(/\/$/, '');
+  }
+
+  const candidates = [
+    process.env.LOCAL_API_URL,
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:3003',
+  ].filter(Boolean);
+
+  return candidates[0]?.replace(/\/$/, '') || 'http://127.0.0.1:3000';
+}
+
+export function expectLegacyDeprecationHeaders(headers, successorPath) {
+  expect(headers.deprecation).toBe('true');
+  expect(headers.link).toMatch(/successor-version/);
+  expect(headers.link).toMatch(new RegExp(successorPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  expect(headers.warning).toMatch(/Legacy \/api\/\* path/);
+}

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const LOADING_TEXT = 'Kraunamos kainos...';
+
 test.describe('frontend smoke', () => {
   test('home redirects to upcoming', async ({ page }) => {
     await page.goto('/');
@@ -7,15 +9,58 @@ test.describe('frontend smoke', () => {
     await expect(page.locator('body')).toBeVisible();
   });
 
-  test('today page loads', async ({ page }) => {
-    await page.goto('/today');
-    await expect(page).toHaveURL(/\/today/);
-    await expect(page.locator('.today-page')).toBeVisible();
+  test('upcoming page loads price table or empty state', async ({ page }) => {
+    await page.goto('/upcoming?lang=lt');
+    await expect(page).toHaveURL(/\/upcoming/);
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+
+    const table = page.locator('table.table');
+    const empty = page.getByText('Nėra artimiausių kainų.');
+    await expect(table.or(empty)).toBeVisible();
+
+    if (await table.isVisible()) {
+      await expect(page.getByText('Vidutinė kaina:')).toBeVisible();
+      await expect(table.locator('tbody tr').first()).toBeVisible();
+    }
   });
 
-  test('settings page loads', async ({ page }) => {
+  test('today page loads with date controls and price table', async ({ page }) => {
+    await page.goto('/today?lang=lt');
+    await expect(page).toHaveURL(/\/today/);
+    const todayPage = page.locator('.today-page');
+    await expect(todayPage).toBeVisible();
+    await expect(todayPage.getByRole('button', { name: 'Šiandien' })).toBeVisible();
+    await expect(todayPage.getByRole('button', { name: 'Rytoj' })).toBeVisible();
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+    await expect(page.locator('table.table')).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('settings page loads alert and color sections', async ({ page }) => {
     await page.goto('/settings?lang=lt');
     await expect(page.getByRole('heading', { name: 'Nustatymai', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Spalvų slenksčiai' })).toBeVisible();
+    await expect(page.getByLabel('Pigi kaina')).toBeVisible();
+    await expect(page.getByLabel('Brangi kaina')).toBeVisible();
+  });
+
+  test('bottom navigation switches between today and upcoming', async ({ page }) => {
+    await page.goto('/upcoming?lang=lt');
+    const nav = page.locator('nav.bottom-menu');
+
+    await nav.getByRole('button', { name: 'Šiandien' }).click();
+    await expect(page).toHaveURL(/\/today/);
+    await expect(page.locator('.today-page')).toBeVisible();
+
+    await nav.getByRole('button', { name: 'Artimiausios' }).click();
+    await expect(page).toHaveURL(/\/upcoming/);
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+  });
+
+  test('bottom navigation opens settings from upcoming', async ({ page }) => {
+    await page.goto('/upcoming?lang=lt');
+    await page.locator('nav.bottom-menu').getByRole('button', { name: 'Nustatymai' }).click();
+    await expect(page).toHaveURL(/\/settings/);
+    await expect(page.getByLabel('Pigi kaina')).toBeVisible({ timeout: 20_000 });
   });
 
   test('API health via frontend proxy', async ({ request }) => {


### PR DESCRIPTION
## Summary
- Expand Playwright smoke tests for **today**, **upcoming**, **settings**, bottom navigation, and **legacy API deprecation headers** (`/api/sync/status`, `/api/nps/prices`).
- Add `tests/e2e/helpers/apiBase.js` for shared legacy header assertions.
- Probe a reachable backend URL in `bin/run-e2e.sh` when `deploy/local.env` points at a stopped port (e.g. 3003 vs 3000).

## Coverage audit
| Area | Before | After |
| --- | --- | --- |
| Today view | `.today-page` visible | Date controls + price table after load |
| Upcoming | redirect only | Price table or empty state |
| Settings | heading only | Color threshold form fields |
| Bottom nav | none | Today ↔ Upcoming; Settings from Upcoming |
| Legacy API | sync status | sync status + nps prices + v1 no-deprecation check |

## Test plan
- [x] `./bin/run-e2e.sh` — 11/11 passed
- [x] `npm test --prefix electricity-prices-build` — 24/24 passed

## Debt filed
Refs #124 — bottom nav settings fails after today→upcoming chain