### PR TITLE
[e2e] Add axe spot-checks and smoke-local Windows build fix

### DIFF
--- a/bin/smoke-local.sh
+++ b/bin/smoke-local.sh
@@ -34,8 +34,7 @@ test -f .env.example
 if command -v npm >/dev/null 2>&1; then
   echo "==> frontend build"
   npm ci --prefix electricity-prices-build
-  # npx resolves local vite on Windows where bare "vite" is not on PATH in npm scripts
-  npm exec --prefix electricity-prices-build -- vite build
+  npm run build --prefix electricity-prices-build
 fi
 
 if curl -sf "${API_URL}/health" >/dev/null 2>&1; then

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from './fixtures/axe.js';
+
+const LOADING_TEXT = 'Kraunamos kainos...';
+
+test.describe('accessibility spot-check', () => {
+  test('today has no critical a11y violations', async ({ page, makeAxeBuilder }) => {
+    await page.goto('/today?lang=lt');
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+    await expect(page.locator('table.table')).toBeVisible({ timeout: 20_000 });
+    const results = await makeAxeBuilder().analyze();
+    expect(results.violations.filter((v) => v.impact === 'critical')).toEqual([]);
+  });
+
+  test('settings has no critical a11y violations', async ({ page, makeAxeBuilder }) => {
+    await page.goto('/settings?lang=lt');
+    await expect(page.getByRole('heading', { name: 'Nustatymai', exact: true })).toBeVisible();
+    await expect(page.getByLabel('Pigi kaina')).toBeVisible();
+    const results = await makeAxeBuilder().analyze();
+    expect(results.violations.filter((v) => v.impact === 'critical')).toEqual([]);
+  });
+});

--- a/tests/e2e/fixtures/axe.js
+++ b/tests/e2e/fixtures/axe.js
@@ -1,0 +1,10 @@
+import { test as base, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+export const test = base.extend({
+  makeAxeBuilder: async ({ page }, use) => {
+    await use(() => new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']));
+  },
+});
+
+export { expect };

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -6,7 +6,21 @@
     "": {
       "name": "nordpool-e2e",
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -23,6 +37,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/playwright": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -8,6 +8,7 @@
     "test:ui": "playwright test --ui"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@playwright/test": "^1.52.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add `@axe-core/playwright` fixture and accessibility specs for `/today` and `/settings` (critical violations only)
- Fix `bin/smoke-local.sh` frontend build on Windows: use `npm run build --prefix electricity-prices-build` instead of bare `vite` via `npm exec`, which failed to resolve the local binary on Windows

Fixes #120

## Test plan
- [x] `npm test --prefix backend` (23 passed)
- [x] `npm run build --prefix electricity-prices-build`
- [x] `./bin/run-e2e.sh` (13 passed, including 2 accessibility specs)
- [x] `bash -n bin/smoke-local.sh`

Made with [Cursor](https://cursor.com)