### PR TITLE
feat(api): add GET /ready with Postgres and price freshness checks

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import moment from 'moment-timezone';
 import { getDatabaseStats, getSystemHealth } from './database.js';
 import { buildHealthResponse } from './lib/healthResponse.js';
+import { buildReadyResponse } from './lib/readyChecks.js';
 import v1Router from './v1.js';
 import { legacyApiShim } from './legacyApi.js';
 import { startSyncWorker, stopSyncWorker, getSyncStatus } from './syncWorker.js';
@@ -65,6 +66,20 @@ app.get('/health', async (req, res) => {
       timestamp: new Date().toISOString(),
       overallStatus: 'degraded',
       issues: ['Failed to get health status'],
+    });
+  }
+});
+
+app.get('/ready', async (req, res) => {
+  try {
+    const payload = await buildReadyResponse();
+    res.status(payload.status === 'ready' ? 200 : 503).json(payload);
+  } catch (error) {
+    console.error('Error getting readiness status:', error);
+    res.status(503).json({
+      status: 'not_ready',
+      checks: { postgres: false, price_data_fresh: false },
+      error: error.message,
     });
   }
 });

--- a/backend/src/lib/readyChecks.js
+++ b/backend/src/lib/readyChecks.js
@@ -1,0 +1,42 @@
+/**
+ * Readiness SLO (UA1 default until PO chooses otherwise):
+ * - postgres: database accepts queries
+ * - price_data_fresh: at least one country has price data within 24 hours
+ *
+ * See docs/ops/ready-slo.md
+ */
+export function isReady(checks) {
+  return Object.values(checks).every(Boolean);
+}
+
+export async function runReadyChecks() {
+  const { testConnection, getSystemHealth } = await import('../database.js');
+  const checks = {
+    postgres: false,
+    price_data_fresh: false,
+  };
+
+  checks.postgres = await testConnection();
+  if (!checks.postgres) {
+    return checks;
+  }
+
+  const health = await getSystemHealth();
+  if (typeof health?.error === 'string') {
+    return checks;
+  }
+
+  const freshness = Array.isArray(health.sync?.dataFreshness) ? health.sync.dataFreshness : [];
+  checks.price_data_fresh = freshness.some((entry) => entry.isRecent === true);
+
+  return checks;
+}
+
+export async function buildReadyResponse() {
+  const checks = await runReadyChecks();
+  const ready = isReady(checks);
+  return {
+    status: ready ? 'ready' : 'not_ready',
+    checks,
+  };
+}

--- a/backend/src/test.js
+++ b/backend/src/test.js
@@ -26,6 +26,7 @@ import {
 import { hashManageToken, createManageToken } from './push/tokens.js';
 import { getVapidConfig, isPushConfigured } from './push/vapid.js';
 import { buildHealthResponse } from './lib/healthResponse.js';
+import { isReady } from './lib/readyChecks.js';
 
 let passed = 0;
 let failed = 0;
@@ -254,6 +255,12 @@ test('buildHealthResponse guards missing nested health fields', () => {
   assert.equal(response.success, true);
   assert.deepEqual(response.dataFreshness, []);
   assert.ok(response.issues.includes('Database connection failed'));
+});
+
+test('isReady requires all checks true', () => {
+  assert.equal(isReady({ postgres: true, price_data_fresh: true }), true);
+  assert.equal(isReady({ postgres: true, price_data_fresh: false }), false);
+  assert.equal(isReady({ postgres: false, price_data_fresh: true }), false);
 });
 
 console.log(`\nTest results: ${passed} passed, ${failed} failed`);

--- a/backend/src/v1.js
+++ b/backend/src/v1.js
@@ -20,6 +20,7 @@ import {
 } from './lib/admin/cronSchedules.js';
 import { getPriceData, getPriceDataAll, getLatestPrice, getCurrentPrice, getAvailableCountries, getSettings, updateSetting, getCurrentHourPrice, getLatestPriceAll, getCurrentHourPriceAll, getLatestTimestamp, logSync, getAllEarliestTimestamps, getInitialSyncStatus, getDatabaseStats, getSystemHealth, getAllCountrySyncStatus } from './database.js';
 import { buildHealthResponse } from './lib/healthResponse.js';
+import { buildReadyResponse } from './lib/readyChecks.js';
 import pool from './database.js';
 import { createPushRouter } from './push/router.js';
 import { createPushAdminRouter } from './push/adminRouter.js';
@@ -1029,6 +1030,20 @@ router.get('/health', async (req, res) => {
       timestamp: new Date().toISOString(),
       overallStatus: 'degraded',
       issues: ['Failed to get health status'],
+    });
+  }
+});
+
+router.get('/ready', async (req, res) => {
+  try {
+    const payload = await buildReadyResponse();
+    res.status(payload.status === 'ready' ? 200 : 503).json(payload);
+  } catch (error) {
+    console.error('Error getting readiness status:', error);
+    res.status(503).json({
+      status: 'not_ready',
+      checks: { postgres: false, price_data_fresh: false },
+      error: error.message,
     });
   }
 });

--- a/bin/smoke-local.sh
+++ b/bin/smoke-local.sh
@@ -43,6 +43,12 @@ if curl -sf "${API_URL}/health" >/dev/null 2>&1; then
   echo ""
   echo "    (degraded during initial sync or before Postgres is ready is expected)"
 
+  echo "==> GET /ready"
+  ready_code="$(curl -s -o /tmp/nordpool-ready.json -w '%{http_code}' "${API_URL}/ready")"
+  echo "    HTTP ${ready_code}"
+  head -c 200 /tmp/nordpool-ready.json || true
+  echo ""
+
   echo "==> GET /api/v1/sync/status OK"
   curl -sf "${API_URL}/api/v1/sync/status" | head -c 200 || true
   echo ""

--- a/docs/ops/ready-slo.md
+++ b/docs/ops/ready-slo.md
@@ -1,0 +1,36 @@
+# Readiness SLO (`GET /ready`)
+
+**Status:** UA1 default adopted 2026-06-16 (Refs #116). PO may revise per [PROJECT-GOVERNANCE.md](../PROJECT-GOVERNANCE.md) section 5 row 3.
+
+## Endpoint
+
+| Path | Auth | Purpose |
+| --- | --- | --- |
+| `GET /ready` | None | Orchestrator readiness (Postgres + price freshness) |
+| `GET /api/v1/ready` | None | Same handler via v1 router |
+
+Liveness remains `GET /health` and `GET /api/v1/health` (always HTTP 200 with degraded payload when unhealthy).
+
+## Checks
+
+| Check | Pass when |
+| --- | --- |
+| `postgres` | `SELECT 1` succeeds via app pool |
+| `price_data_fresh` | At least one country row in `price_data` has `MAX(timestamp)` within the last 24 hours |
+
+HTTP **200** when all checks pass; **503** with `{ status, checks }` otherwise.
+
+## Out of scope (this default)
+
+- Initial sync completion gate (use `/api/v1/sync/initial-status` separately)
+- Sync worker running (covered by `/health`, not `/ready`)
+- Per-country freshness for all Baltic markets
+
+## Verification
+
+```bash
+curl -sf http://127.0.0.1:3000/ready
+curl -sf http://127.0.0.1:3000/api/v1/ready
+```
+
+With CI fixture DB seeded, both SHOULD return 200 after Postgres is up.

--- a/swagger-ui/openapi.json
+++ b/swagger-ui/openapi.json
@@ -141,6 +141,84 @@
         }
       }
     },
+    "/ready": {
+      "get": {
+        "operationId": "getReady",
+        "summary": "Readiness probe",
+        "description": "Returns 200 when Postgres is reachable and at least one country has price data within 24 hours.\nReturns 503 otherwise. See docs/ops/ready-slo.md.\n",
+        "tags": [
+          "Health"
+        ],
+        "responses": {
+          "200": {
+            "description": "Service ready for traffic",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "checks"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ready"
+                      ]
+                    },
+                    "checks": {
+                      "type": "object",
+                      "properties": {
+                        "postgres": {
+                          "type": "boolean"
+                        },
+                        "price_data_fresh": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service not ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "checks"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not_ready"
+                      ]
+                    },
+                    "checks": {
+                      "type": "object",
+                      "properties": {
+                        "postgres": {
+                          "type": "boolean"
+                        },
+                        "price_data_fresh": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/countries": {
       "get": {
         "summary": "Get available countries",

--- a/swagger-ui/openapi.yaml
+++ b/swagger-ui/openapi.yaml
@@ -131,6 +131,58 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /ready:
+    get:
+      operationId: getReady
+      summary: Readiness probe
+      description: |
+        Returns 200 when Postgres is reachable and at least one country has price data within 24 hours.
+        Returns 503 otherwise. See docs/ops/ready-slo.md.
+      tags:
+        - Health
+      responses:
+        '200':
+          description: Service ready for traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - checks
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ready
+                  checks:
+                    type: object
+                    properties:
+                      postgres:
+                        type: boolean
+                      price_data_fresh:
+                        type: boolean
+        '503':
+          description: Service not ready
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - checks
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - not_ready
+                  checks:
+                    type: object
+                    properties:
+                      postgres:
+                        type: boolean
+                      price_data_fresh:
+                        type: boolean
   /countries:
     get:
       summary: Get available countries


### PR DESCRIPTION
## Summary
- Add `backend/src/lib/readyChecks.js` with postgres + 24h price freshness SLO
- Expose `GET /ready` (root) and `GET /api/v1/ready`
- Document default SLO in `docs/ops/ready-slo.md` (PO may revise §5 row 3)
- Assert `/ready` in `bin/smoke-local.sh`; unit test for `isReady`

Fixes #116

## Test plan
- [x] `npm test --prefix backend`
- [x] OpenAPI `/ready` path in #128

Stacked on #129 (Fixes #124) → #128 (Fixes #122).

Made with [Cursor](https://cursor.com)