### PR TITLE
[frontend] Fix Today empty state date picker and zero average

### DIFF
--- a/electricity-prices-build/src/components/PriceTable.vue
+++ b/electricity-prices-build/src/components/PriceTable.vue
@@ -73,8 +73,8 @@ onUnmounted(() => {
 const averagePrice = computed(() => {
   // Use allPriceData for average calculation if provided, otherwise use priceData
   const dataToUse = props.allPriceData || props.priceData;
-  
-  if (!dataToUse.length) return 0;
+
+  if (!hasEnoughData.value || !dataToUse.length) return null;
   const sum = dataToUse.reduce((acc, price) => acc + parseFloat(calculatePrice(price)), 0);
   return sum / dataToUse.length;
 });
@@ -221,7 +221,7 @@ const groupedByHour = computed(() => {
           <th :colspan="layoutMode === 'slot' ? 0 : slotsPerHour * 2" class="text-end sticky-top bg-body">
             <div class="d-flex align-items-center justify-content-end gap-2">
               <span class="fw-bold mb-0">{{ $t('table.averageLabel') }}</span>
-              <span class="badge bg-primary">{{ averagePrice.toFixed(3) }} ct/kWh</span>
+              <span v-if="averagePrice != null" class="badge bg-primary">{{ averagePrice.toFixed(3) }} ct/kWh</span>
             </div>
           </th>
         </tr>

--- a/electricity-prices-build/src/views/TodayView.vue
+++ b/electricity-prices-build/src/views/TodayView.vue
@@ -1,6 +1,6 @@
 <script setup>
 
-import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 
 import { useRoute, onBeforeRouteLeave } from 'vue-router'
 
@@ -36,27 +36,35 @@ const route = useRoute();
 
 
 
-function resolveInitialDate() {
+function formatDisplayDate(value) {
 
-  const queryDate = route.query.date;
-
-  if (typeof queryDate === 'string' && moment.tz(queryDate, DISPLAY_TIMEZONE).isValid()) {
-
-    return moment.tz(queryDate, DISPLAY_TIMEZONE).startOf('day').toDate();
-
-  }
-
-  return moment().tz(DISPLAY_TIMEZONE).startOf('day').toDate();
+  return moment.tz(value, DISPLAY_TIMEZONE).format('YYYY-MM-DD');
 
 }
 
 
 
-const date = ref(resolveInitialDate());
+function resolveInitialDateStr() {
 
-const minDate = moment.tz('2012-07-01', DISPLAY_TIMEZONE).startOf('day').toDate();
+  const queryDate = route.query.date;
 
-const maxDate = moment().tz(DISPLAY_TIMEZONE).add(1, 'day').startOf('day').toDate();
+  if (typeof queryDate === 'string' && moment.tz(queryDate, DISPLAY_TIMEZONE).isValid()) {
+
+    return formatDisplayDate(queryDate);
+
+  }
+
+  return formatDisplayDate(moment().tz(DISPLAY_TIMEZONE));
+
+}
+
+
+
+const selectedDate = ref(resolveInitialDateStr());
+
+const minDate = '2012-07-01';
+
+const maxDate = computed(() => formatDisplayDate(moment().tz(DISPLAY_TIMEZONE).add(1, 'day')));
 
 const priceData = ref([]);
 
@@ -69,6 +77,14 @@ const error = ref(null);
 let refreshTimeout = null;
 
 let unsubscribePrices = null;
+
+
+
+function selectedDateAsDate() {
+
+  return moment.tz(selectedDate.value, DISPLAY_TIMEZONE).startOf('day').toDate();
+
+}
 
 
 
@@ -138,7 +154,7 @@ async function reloadPrices() {
 
     error.value = null;
 
-    const data = await fetchPrices(date.value);
+    const data = await fetchPrices(selectedDateAsDate());
 
     priceData.value = data.data?.lt || [];
 
@@ -197,7 +213,7 @@ onUnmounted(() => {
 
 
 
-watch(date, () => {
+watch(selectedDate, () => {
 
   reloadPrices();
 
@@ -224,7 +240,7 @@ function updateTodaySEO() {
 
       : 'Display Nord Pool electricity prices with all applicable taxes and fees. Prices are updated automatically.');
 
-  const dateStr = moment(date.value).tz(DISPLAY_TIMEZONE).format('YYYY-MM-DD');
+  const dateStr = selectedDate.value;
 
   const path = `/today?date=${dateStr}`;
 
@@ -272,7 +288,7 @@ function updateTodaySEO() {
 
 
 
-watch([priceData, date], () => {
+watch([priceData, selectedDate], () => {
 
   updateTodaySEO();
 
@@ -282,7 +298,7 @@ watch([priceData, date], () => {
 
 function setToday() {
 
-  date.value = moment().tz(DISPLAY_TIMEZONE).startOf('day').toDate();
+  selectedDate.value = formatDisplayDate(moment().tz(DISPLAY_TIMEZONE));
 
 }
 
@@ -290,7 +306,7 @@ function setToday() {
 
 function setTomorrow() {
 
-  date.value = moment().tz(DISPLAY_TIMEZONE).add(1, 'day').startOf('day').toDate();
+  selectedDate.value = formatDisplayDate(moment().tz(DISPLAY_TIMEZONE).add(1, 'day'));
 
 }
 
@@ -306,7 +322,9 @@ function setTomorrow() {
 
       <div class="d-flex gap-2 mb-3">
 
-        <VueDatePicker v-model="date" locale="lt" month-name-format="long" format="yyyy-MM-dd"
+        <VueDatePicker v-model="selectedDate" locale="lt" month-name-format="long" format="yyyy-MM-dd"
+
+          model-type="yyyy-MM-dd" :timezone="DISPLAY_TIMEZONE"
 
           auto-apply reverse-years :enable-time-picker="false"
 
@@ -369,5 +387,4 @@ function setTomorrow() {
 }
 
 </style>
-
 

--- a/electricity-prices-build/tests/priceTable.test.js
+++ b/electricity-prices-build/tests/priceTable.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import moment from 'moment-timezone';
+import PriceTable from '../src/components/PriceTable.vue';
+
+vi.mock('../src/services/timeService.js', () => ({
+  formatPriceHours: vi.fn((ts) => String(ts)),
+  isCurrentHour: vi.fn(() => false),
+}));
+
+vi.mock('../src/services/priceCalculationService.js', () => ({
+  calculatePrice: vi.fn((row) => row.price / 10),
+  getTimePeriod: vi.fn(() => 'day'),
+}));
+
+vi.mock('../src/services/alertSettingsService.js', () => ({
+  getColorThresholdSettings: vi.fn(() => ({
+    cheapRange: 10,
+    expensiveRange: 10,
+    absoluteCheap: 0,
+    absoluteExpensive: 999,
+  })),
+}));
+
+vi.mock('../src/utils/priceColor.js', () => ({
+  getPriceClass: vi.fn(() => ({ classes: '' })),
+}));
+
+const hourlyRows = (count, basePrice = 45) =>
+  Array.from({ length: count }, (_, index) => ({
+    timestamp: moment.tz('2024-06-15 00:00', 'Europe/Vilnius').add(index, 'hours').unix(),
+    price: basePrice + index,
+  }));
+
+describe('PriceTable empty state', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+  });
+
+  it('shows warning only when fewer than three price rows', () => {
+    const wrapper = mount(PriceTable, {
+      props: { priceData: [] },
+      global: { mocks: { $t: (key) => key } },
+    });
+
+    expect(wrapper.find('.alert-warning').exists()).toBe(true);
+    expect(wrapper.find('table.table').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('0.000');
+  });
+
+  it('shows average badge when enough hourly rows exist', () => {
+    const wrapper = mount(PriceTable, {
+      props: { priceData: hourlyRows(3) },
+      global: { mocks: { $t: (key) => key } },
+    });
+
+    expect(wrapper.find('.alert-warning').exists()).toBe(false);
+    expect(wrapper.find('table.table').exists()).toBe(true);
+    expect(wrapper.find('.badge.bg-primary').exists()).toBe(true);
+    expect(wrapper.findAll('tbody tr').length).toBe(3);
+  });
+});

--- a/electricity-prices-build/tests/views.smoke.test.js
+++ b/electricity-prices-build/tests/views.smoke.test.js
@@ -81,7 +81,10 @@ describe('TodayView smoke', () => {
     const wrapper = mount(TodayView, {
       global: {
         stubs: {
-          VueDatePicker: true,
+          VueDatePicker: {
+            template: '<input class="date-picker-stub" :value="modelValue" readonly />',
+            props: ['modelValue'],
+          },
           PriceTable: {
             template: '<div class="price-table-stub">{{ priceData.length }}</div>',
             props: ['priceData'],
@@ -93,6 +96,38 @@ describe('TodayView smoke', () => {
     await flushPromises();
     await flushPromises();
     expect(wrapper.find('.price-table-stub').text()).toBe('3');
+    expect(wrapper.find('.date-picker-stub').element.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('keeps selected date visible when API returns no prices', async () => {
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    fetchPrices.mockResolvedValueOnce({
+      success: true,
+      data: { lt: [] },
+      meta: { country: 'lt', count: 0, timezone: 'Europe/Vilnius' },
+    });
+
+    const TodayView = (await import('../src/views/TodayView.vue')).default;
+    const wrapper = mount(TodayView, {
+      global: {
+        stubs: {
+          VueDatePicker: {
+            template: '<input class="date-picker-stub" :value="modelValue" readonly />',
+            props: ['modelValue'],
+          },
+          PriceTable: {
+            template: '<div class="price-table-stub" data-empty="true"></div>',
+            props: ['priceData'],
+          },
+        },
+        mocks: { $t: (key) => key },
+      },
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(wrapper.find('.date-picker-stub').element.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(wrapper.find('[data-empty="true"]').exists()).toBe(true);
   });
 });
 

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -24,7 +24,7 @@ test.describe('frontend smoke', () => {
     }
   });
 
-  test('today page loads with date controls and price table', async ({ page }) => {
+  test('today page loads with date controls and price or empty state', async ({ page }) => {
     await page.goto('/today?lang=lt');
     await expect(page).toHaveURL(/\/today/);
     const todayPage = page.locator('.today-page');
@@ -32,7 +32,39 @@ test.describe('frontend smoke', () => {
     await expect(todayPage.getByRole('button', { name: 'Šiandien' })).toBeVisible();
     await expect(todayPage.getByRole('button', { name: 'Rytoj' })).toBeVisible();
     await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
-    await expect(page.locator('table.table')).toBeVisible({ timeout: 20_000 });
+
+    const dateInput = todayPage.locator('.dp__input');
+    await expect(dateInput).toBeVisible();
+    await expect(dateInput).toHaveValue(/\d{4}-\d{2}-\d{2}/);
+
+    const table = page.locator('table.table');
+    const emptyWarning = page.getByText('Šiai datai kainų duomenys dar nepasiekiami.');
+    await expect(table.or(emptyWarning)).toBeVisible();
+
+    if (await table.isVisible()) {
+      await expect(page.getByText('Vidutinė kaina:')).toBeVisible();
+      await expect(table.locator('tbody tr').first()).toBeVisible();
+      await expect(page.getByText('0.000 ct/kWh')).toHaveCount(0);
+    } else {
+      await expect(page.getByText('0.000 ct/kWh')).toHaveCount(0);
+    }
+  });
+
+  test('today tomorrow button keeps date visible in empty-data window', async ({ page }) => {
+    await page.goto('/today?lang=lt');
+    const todayPage = page.locator('.today-page');
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+
+    await todayPage.getByRole('button', { name: 'Rytoj' }).click();
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+
+    const dateInput = todayPage.locator('.dp__input');
+    await expect(dateInput).toHaveValue(/\d{4}-\d{2}-\d{2}/);
+
+    const table = page.locator('table.table');
+    const emptyWarning = page.getByText('Šiai datai kainų duomenys dar nepasiekiami.');
+    await expect(table.or(emptyWarning)).toBeVisible();
+    await expect(page.getByText('0.000 ct/kWh')).toHaveCount(0);
   });
 
   test('settings page loads alert and color sections', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes the broken Today view when tomorrow's prices are not yet available (before Nord Pool release window or empty DB):

- **Date picker** now binds to `YYYY-MM-DD` strings with `timezone="Europe/Vilnius"` so the selected day stays visible instead of rendering blank
- **Average price** no longer falls back to `0.000 ct/kWh` when fewer than three rows exist; empty data shows the warning banner only (no table headers)
- **Tests** added for `PriceTable` empty state, `TodayView` empty API response, and E2E assertions for date input value + no zero average

## Root cause

`VueDatePicker` was bound to native `Date` objects created via `moment.tz(...).toDate()` without a `timezone` prop. In non-Vilnius browser timezones the internal day could fall outside `min/max` or fail to format, leaving the input empty. When `< 3` price rows were returned, older builds also rendered the table shell with `averagePrice` defaulting to `0`.

## Test plan

- [x] `npm test --prefix electricity-prices-build` (27 passed)
- [x] `npm run build --prefix electricity-prices-build`
- [ ] `./bin/run-e2e.sh` (today empty-state scenarios in `tests/e2e/smoke.spec.js`)

Fixes #134

Made with [Cursor](https://cursor.com)