### PR TITLE
[frontend] Include current MTU slot in upcoming view

### DIFF
--- a/electricity-prices-build/src/components/UpcomingPrices.vue
+++ b/electricity-prices-build/src/components/UpcomingPrices.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, ref, onMounted } from 'vue';
-import { formatPriceHours, isCurrentHour } from '../services/timeService';
+import { formatPriceHours, isCurrentHour, filterUpcomingSlots } from '../services/timeService';
 import { calculatePrice } from '../services/priceCalculationService';
 
 const props = defineProps({
@@ -30,9 +30,7 @@ const saveSettings = () => {
 };
 
 const upcomingPrices = computed(() => {
-  const nowSec = Math.floor(Date.now() / 1000);
-  return props.priceData
-    .filter(price => price.timestamp >= nowSec)
+  return filterUpcomingSlots(props.priceData, intervalSeconds.value)
     .slice(0, settings.value.numberOfHours);
 });
 

--- a/electricity-prices-build/src/components/display/DisplayChartPanel.vue
+++ b/electricity-prices-build/src/components/display/DisplayChartPanel.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { calculatePrice } from '../../services/priceCalculationService';
-import { formatPriceHours, isCurrentHour } from '../../services/timeService';
+import { formatPriceHours, isCurrentHour, filterUpcomingSlots } from '../../services/timeService';
 
 const props = defineProps({
   priceData: {
@@ -28,9 +28,7 @@ const intervalSeconds = computed(() => {
 });
 
 const chartRows = computed(() => {
-  const nowSec = Math.floor(Date.now() / 1000);
-  const upcoming = props.priceData
-    .filter((row) => row.timestamp >= nowSec)
+  const upcoming = filterUpcomingSlots(props.priceData, intervalSeconds.value)
     .slice(0, props.maxHours);
 
   if (upcoming.length === 0) {

--- a/electricity-prices-build/src/services/priceCacheService.js
+++ b/electricity-prices-build/src/services/priceCacheService.js
@@ -10,6 +10,7 @@ import {
   isDaySynced,
   clearDaySync,
 } from '../utils/deviceSyncState';
+import { filterUpcomingSlots } from './timeService';
 
 const CACHE_KEY = 'priceDataCache';
 const CACHE_VERSION = 1;
@@ -87,10 +88,10 @@ export function getCachedUpcomingPrices(country = 'lt') {
   
   if (countryData.length === 0) return null;
   
-  const now = moment().tz('Europe/Vilnius').unix();
-  const filtered = countryData.filter(price => price.timestamp >= now);
-  
-  return filtered.length > 0 ? filtered.sort((a, b) => a.timestamp - b.timestamp) : null;
+  const intervalSeconds = inferMtuIntervalSeconds(countryData);
+  const filtered = filterUpcomingSlots(countryData, intervalSeconds);
+
+  return filtered.length > 0 ? filtered : null;
 }
 
 /**

--- a/electricity-prices-build/src/services/timeService.js
+++ b/electricity-prices-build/src/services/timeService.js
@@ -1,4 +1,48 @@
 import moment from 'moment-timezone';
+import { DISPLAY_TIMEZONE } from '../utils/releaseWindow';
+
+export function inferIntervalSecondsFromPrices(prices) {
+  if (!prices || prices.length < 2) {
+    return 3600;
+  }
+  const diff = prices[1].timestamp - prices[0].timestamp;
+  return diff > 0 ? diff : 3600;
+}
+
+/**
+ * Whether a price slot is the active MTU or starts in the future (Vilnius display TZ).
+ */
+export function isCurrentOrFutureSlot(
+  timestamp,
+  intervalSeconds = 3600,
+  now = moment(),
+  timezone = DISPLAY_TIMEZONE,
+) {
+  const nowLocal = now.clone().tz(timezone);
+  const start = moment.unix(timestamp).tz(timezone);
+  const end = start.clone().add(intervalSeconds, 'seconds');
+  const isCurrentSlot = start.isSameOrBefore(nowLocal) && end.isAfter(nowLocal);
+  const isFutureSlot = start.isAfter(nowLocal);
+  return isCurrentSlot || isFutureSlot;
+}
+
+/**
+ * Keep the active MTU slot plus all future slots for the day (matches backend /upcoming).
+ */
+export function filterUpcomingSlots(
+  prices,
+  intervalSeconds,
+  now = moment(),
+  timezone = DISPLAY_TIMEZONE,
+) {
+  if (!prices || prices.length === 0) {
+    return [];
+  }
+  const interval = intervalSeconds ?? inferIntervalSecondsFromPrices(prices);
+  return prices
+    .filter((price) => isCurrentOrFutureSlot(price.timestamp, interval, now, timezone))
+    .sort((a, b) => a.timestamp - b.timestamp);
+}
 
 export function formatPriceHours(time, intervalSeconds = 3600) {
   const start = moment.unix(time);
@@ -29,10 +73,9 @@ export function formatLocalTime(timestamp) {
   });
 }
 
-export function isCurrentHour(time, intervalSeconds = 3600) {
-  const now = moment();
-  const start = moment.unix(time);
+export function isCurrentHour(time, intervalSeconds = 3600, timezone = DISPLAY_TIMEZONE) {
+  const now = moment().tz(timezone);
+  const start = moment.unix(time).tz(timezone);
   const end = start.clone().add(intervalSeconds, 'seconds');
-  // Same calendar day and now is within [start, end)
   return now.isSame(start, 'day') && now.isBetween(start, end, null, '[)');
 }

--- a/electricity-prices-build/tests/timeService.test.js
+++ b/electricity-prices-build/tests/timeService.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import moment from 'moment-timezone';
+import {
+  filterUpcomingSlots,
+  isCurrentOrFutureSlot,
+  isCurrentHour,
+} from '../src/services/timeService.js';
+import { DISPLAY_TIMEZONE } from '../src/utils/releaseWindow.js';
+
+const INTERVAL_15_MIN = 900;
+
+function mtuSlotsForDay(dateStr, count = 8) {
+  const start = moment.tz(`${dateStr} 03:00`, DISPLAY_TIMEZONE);
+  return Array.from({ length: count }, (_, index) => ({
+    timestamp: start.clone().add(index * 15, 'minutes').unix(),
+    price: 40 + index,
+  }));
+}
+
+describe('filterUpcomingSlots', () => {
+  it('includes the active 15-min slot at 03:48 Vilnius', () => {
+    const now = moment.tz('2026-06-16 03:48', DISPLAY_TIMEZONE);
+    const slots = mtuSlotsForDay('2026-06-16');
+    const filtered = filterUpcomingSlots(slots, INTERVAL_15_MIN, now);
+
+    expect(filtered.map((row) => moment.unix(row.timestamp).tz(DISPLAY_TIMEZONE).format('HH:mm'))).toEqual([
+      '03:45',
+      '04:00',
+      '04:15',
+      '04:30',
+      '04:45',
+    ]);
+  });
+
+  it('excludes past slots before the active MTU boundary', () => {
+    const now = moment.tz('2026-06-16 03:48', DISPLAY_TIMEZONE);
+    const slots = mtuSlotsForDay('2026-06-16');
+    const filtered = filterUpcomingSlots(slots, INTERVAL_15_MIN, now);
+
+    expect(filtered.some((row) => moment.unix(row.timestamp).tz(DISPLAY_TIMEZONE).format('HH:mm') === '03:30')).toBe(false);
+    expect(filtered.some((row) => moment.unix(row.timestamp).tz(DISPLAY_TIMEZONE).format('HH:mm') === '03:45')).toBe(true);
+  });
+
+  it('includes the active hourly slot at 14:30 Vilnius', () => {
+    const now = moment.tz('2026-06-16 14:30', DISPLAY_TIMEZONE);
+    const slots = Array.from({ length: 4 }, (_, index) => ({
+      timestamp: moment.tz('2026-06-16 14:00', DISPLAY_TIMEZONE).add(index, 'hours').unix(),
+      price: 50,
+    }));
+    const filtered = filterUpcomingSlots(slots, 3600, now);
+
+    expect(filtered.map((row) => moment.unix(row.timestamp).tz(DISPLAY_TIMEZONE).format('HH:mm'))).toEqual([
+      '14:00',
+      '15:00',
+      '16:00',
+      '17:00',
+    ]);
+  });
+});
+
+describe('isCurrentOrFutureSlot', () => {
+  it('treats the slot containing now as current', () => {
+    const now = moment.tz('2026-06-16 03:48', DISPLAY_TIMEZONE);
+    const currentStart = moment.tz('2026-06-16 03:45', DISPLAY_TIMEZONE).unix();
+
+    expect(isCurrentOrFutureSlot(currentStart, INTERVAL_15_MIN, now)).toBe(true);
+  });
+
+  it('treats earlier slots as neither current nor future', () => {
+    const now = moment.tz('2026-06-16 03:48', DISPLAY_TIMEZONE);
+    const pastStart = moment.tz('2026-06-16 03:30', DISPLAY_TIMEZONE).unix();
+
+    expect(isCurrentOrFutureSlot(pastStart, INTERVAL_15_MIN, now)).toBe(false);
+  });
+});
+
+describe('isCurrentHour', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses Vilnius timezone for the active slot', () => {
+    const slotStart = moment.tz('2026-06-16 03:45', DISPLAY_TIMEZONE).unix();
+    vi.useFakeTimers();
+    vi.setSystemTime(moment.tz('2026-06-16 03:48', DISPLAY_TIMEZONE).toDate());
+
+    expect(isCurrentHour(slotStart, INTERVAL_15_MIN, DISPLAY_TIMEZONE)).toBe(true);
+  });
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -24,6 +24,39 @@ test.describe('frontend smoke', () => {
     }
   });
 
+  test('upcoming grid includes the active 15-min slot', async ({ page }) => {
+    const frozenNow = new Date('2026-06-16T03:48:00+03:00');
+    const slot = (hour, minute) =>
+      Math.floor(new Date(`2026-06-16T${hour}:${minute}:00+03:00`).getTime() / 1000);
+    const cachePayload = {
+      version: 1,
+      data: {
+        lt: [
+          { timestamp: slot('03', '30'), price: 41.1 },
+          { timestamp: slot('03', '45'), price: 42.2 },
+          { timestamp: slot('04', '00'), price: 43.3 },
+          { timestamp: slot('04', '15'), price: 44.4 },
+          { timestamp: slot('04', '30'), price: 45.5 },
+        ],
+      },
+      lastUpdated: slot('03', '45'),
+    };
+
+    await page.clock.install({ time: frozenNow });
+    await page.addInitScript((payload) => {
+      localStorage.setItem('priceDataCache', JSON.stringify(payload));
+    }, cachePayload);
+
+    await page.goto('/upcoming?lang=lt');
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+
+    const table = page.locator('table.table');
+    await expect(table).toBeVisible();
+    await expect(table.locator('tbody tr')).toHaveCount(2);
+    await expect(table.locator('tbody tr').first()).toContainText('03');
+    await expect(table.locator('tbody tr').first()).toContainText('45');
+  });
+
   test('today page loads with date controls and price or empty state', async ({ page }) => {
     await page.goto('/today?lang=lt');
     await expect(page).toHaveURL(/\/today/);


### PR DESCRIPTION
## Summary
- Root cause: frontend upcoming filters used `timestamp >= now`, excluding the active 15-min slot whose start is already in the past (e.g. 03:45 at 03:48).
- Added shared `filterUpcomingSlots` / `isCurrentOrFutureSlot` in `timeService.js` (Europe/Vilnius, matches backend `/nps/prices/upcoming`).
- Wired cache (`getCachedUpcomingPrices`), `UpcomingPrices.vue`, and `DisplayChartPanel.vue` to the shared filter; fixed `isCurrentHour` to use Vilnius TZ.

## Test plan
- [x] `npm test --prefix electricity-prices-build` (33 passed, incl. new `timeService.test.js`)
- [x] `CI=1 SKIP_WEB_SERVER= npx playwright test smoke.spec.js -g "active 15-min"` in `tests/e2e`
- [ ] CI lint-and-unit + Gitleaks on PR

Fixes #139

Made with [Cursor](https://cursor.com)