### PR TITLE
[ops] Complete env SSOT (#117) and close UA6 (#118)

### DIFF
--- a/bin/capture-db-lfs.sh
+++ b/bin/capture-db-lfs.sh
@@ -5,12 +5,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-if [[ -f deploy/local.env ]]; then
-  # shellcheck disable=SC1091
-  set -a
-  source deploy/local.env
-  set +a
-fi
+# shellcheck source=load-env.sh
+source "${ROOT}/bin/load-env.sh"
 
 POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
 POSTGRES_USER="${POSTGRES_USER:-electricity_user}"

--- a/bin/compose.sh
+++ b/bin/compose.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
-# Docker Compose wrapper — loads deploy/local.env for port and URL substitution.
+# Docker Compose wrapper — loads deploy/local.env (+ optional override) via load-env.sh.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ENV_FILE="${ROOT}/deploy/local.env"
-if [[ ! -f "${ENV_FILE}" ]]; then
-  ENV_FILE="${ROOT}/deploy/local.env.example"
-fi
-exec docker compose --env-file "${ENV_FILE}" "$@"
+# shellcheck source=load-env.sh
+source "${ROOT}/bin/load-env.sh"
+exec docker compose "$@"

--- a/bin/restore-db-lfs.sh
+++ b/bin/restore-db-lfs.sh
@@ -5,12 +5,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-if [[ -f deploy/local.env ]]; then
-  # shellcheck disable=SC1091
-  set -a
-  source deploy/local.env
-  set +a
-fi
+# shellcheck source=load-env.sh
+source "${ROOT}/bin/load-env.sh"
 
 POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
 POSTGRES_USER="${POSTGRES_USER:-electricity_user}"

--- a/bin/server-backup.sh
+++ b/bin/server-backup.sh
@@ -6,12 +6,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-if [[ -f deploy/local.env ]]; then
-  # shellcheck disable=SC1091
-  set -a
-  source deploy/local.env
-  set +a
-fi
+# shellcheck source=load-env.sh
+source "${ROOT}/bin/load-env.sh"
 
 POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
 POSTGRES_USER="${POSTGRES_USER:-electricity_user}"

--- a/bin/server-restore-drill.sh
+++ b/bin/server-restore-drill.sh
@@ -6,12 +6,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-if [[ -f deploy/local.env ]]; then
-  # shellcheck disable=SC1091
-  set -a
-  source deploy/local.env
-  set +a
-fi
+# shellcheck source=load-env.sh
+source "${ROOT}/bin/load-env.sh"
 
 POSTGRES_DB="${POSTGRES_DB:-electricity_prices}"
 POSTGRES_USER="${POSTGRES_USER:-electricity_user}"

--- a/docs/PROJECT-GOVERNANCE.md
+++ b/docs/PROJECT-GOVERNANCE.md
@@ -96,12 +96,12 @@ Blockers → UA0 → UA1 → UA2 → UA3 → UA4 → UA5 → UA6 → UA7 → UA8
 | --- | --- | --- | --- |
 | **Blockers** | Human decisions before feature work | **Partially open** | See §5 |
 | **UA0** | Hygiene, AGENTS.md, templates, agent infra | **Mostly done**; v0.7.1 cursor rules pending | #2 closed; **#115 open** |
-| **UA1** | `/ready`, env single source, nginx alignment | **Partial** | `/health` exists; **#116**, **#117** |
+| **UA1** | `/ready`, env single source, nginx alignment | **Done** | `/ready` #116; env SSOT #117 |
 | **UA2** | CI fixture DB, integration tests | **Done** | #4; golden harness, `ci-integration.yml` |
 | **UA3** | OpenAPI repair, Spectral, `/docs` UX | **In progress** | #101; Spectral `spectral:oas` (#128); live contract CI (#136); **#122** closed |
 | **UA4** | Golden price / DST / MTU harness | **Planned** | Product golden data in-repo |
 | **UA5** | Split `syncWorker.js`, advisory lock | **Planned** | Blocked on worker architecture decision |
-| **UA6** | Post-deploy smoke, Coolify runbook | **Planned** | **#118** |
+| **UA6** | Post-deploy smoke, Coolify runbook | **Done** | #118; [docs/ops/post-deploy-verification.md](ops/post-deploy-verification.md) |
 | **UA7–UA8** | PWA shell, client storage tiers | **Planned** | Not installed |
 | **UA9** | Push scaffold | **Optional** | Not started |
 | **UA10** | Debt register, checklists, adoption log | **In progress** | **#119**; register + `ua-testing` checklist landed; `PROGRESS_LOG.md` active |
@@ -139,8 +139,8 @@ Blockers → UA0 → UA1 → UA2 → UA3 → UA4 → UA5 → UA6 → UA7 → UA8
 | `debt.yml` issue template | #115 |
 | `STRATEGY.md`, `PROGRESS_LOG.md` | #115, #119 |
 | `GET /ready` + freshness SLO | **Done** — [docs/ops/ready-slo.md](ops/ready-slo.md); #116 closed |
-| `load-env.sh` / `compose.sh` single source | #117 |
-| `post-deploy-smoke.sh`, `bulletproof.sh` | #118 (depends on `/ready`) |
+| `load-env.sh` / `compose.sh` single source | **Done** — #117; [PROJECT-GUIDANCE.md](PROJECT-GUIDANCE.md) |
+| `post-deploy-smoke.sh`, `bulletproof.sh` | **Done** — #118 |
 | `review-debt-register.md`, ua checklists | #119 |
 | Full `spectral:oas` ruleset | Spectral crash; #122 |
 | Worker split + advisory lock | PO decision §5; UA5 |

--- a/docs/PROJECT-GUIDANCE.md
+++ b/docs/PROJECT-GUIDANCE.md
@@ -4,3 +4,18 @@ This file was replaced by **[PROJECT-GOVERNANCE.md](PROJECT-GOVERNANCE.md)** —
 
 - **Operators:** [README.md](../README.md)
 - **Agents:** [AGENTS.md](../AGENTS.md)
+
+## Env single source (UA1, #117)
+
+Local ports and URLs MUST come from one loading path so scripts, Compose, and E2E stay aligned.
+
+| File | Purpose |
+| --- | --- |
+| `deploy/local.env` | Canonical local config (copy from `deploy/local.env.example`; gitignored) |
+| `deploy/local.override.env` | Optional per-machine overrides (copy from `deploy/local.override.env.example`; gitignored) |
+| `bin/load-env.sh` | Sources `local.env` (or example) then `local.override.env`; export vars for scripts |
+| `bin/compose.sh` | Compose wrapper that sources `load-env.sh` before `docker compose` |
+
+**Script convention:** every `bin/*.sh` that needs ports or URLs MUST `source "${ROOT}/bin/load-env.sh"` (or call `bin/compose.sh` for Compose). E2E reads `FRONTEND_URL` / `API_URL` / `LOCAL_*` from the same source via `bin/run-e2e.sh`.
+
+First-time setup: `./scripts/dev.sh` seeds `deploy/local.env` from the example. See [AGENTS.md](../AGENTS.md) local verification and [docs/ops/post-deploy-verification.md](ops/post-deploy-verification.md) for smoke URLs.

--- a/docs/checklists/ua-testing.md
+++ b/docs/checklists/ua-testing.md
@@ -31,8 +31,8 @@ Use after UA2 (CI scaffold green). Aligns with [agentic-workflow-plan.md](../pla
 ## L4 — Boot smoke (local + post-deploy)
 
 - [x] `bin/smoke-local.sh`: compose lint, file asserts, optional live `/health`
-- [ ] `bin/post-deploy-smoke.sh`: `/ready` + one golden scenario (#118)
-- [ ] URLs from single env source (#117)
+- [x] `bin/post-deploy-smoke.sh`: `/ready` + one golden scenario (#118)
+- [x] URLs from single env source (#117)
 
 ## L5 — E2E UI (scheduled + local)
 

--- a/docs/review-debt-register.md
+++ b/docs/review-debt-register.md
@@ -6,8 +6,8 @@ Index of known tech debt, bugs, and follow-ups. Link GitHub issues; do not dupli
 | --- | --- | --- | --- | --- |
 | UA3 | [#101](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/101) OpenAPI contract hygiene, Spectral, `/docs` UX | P1 | API / docs | Open |
 | UA3 | [#136](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/136) Live API contract samples in CI | P1 | CI / contract | In progress |
-| UA1 | [#117](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/117) Env single source (`load-env.sh`, `compose.sh`) | P2 | DevOps | Open |
-| UA6 | [#118](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/118) Post-deploy smoke + bulletproof scripts | P2 | CI / ops | Open |
+| UA1 | [#117](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/117) Env single source (`load-env.sh`, `compose.sh`) | P2 | DevOps | Closed via #138 + env SSOT PR |
+| UA6 | [#118](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/118) Post-deploy smoke + bulletproof scripts | P2 | CI / ops | Closed via #138 |
 | UA10 | [#119](https://github.com/alicemq/lt-electricity-full-price-nordpool/issues/119) Debt register, UA checklists, adoption log | P2 | Docs | In progress |
 
 ## Blockers (PO decisions)


### PR DESCRIPTION
## Summary

- #138 merged `load-env.sh`, `compose.sh`, `post-deploy-smoke.sh`, and `bulletproof.sh`; this PR completes remaining **#117** AC: all `bin/*.sh` scripts source `load-env.sh`, `compose.sh` loads optional `local.override.env`, and env SSOT is documented in `docs/PROJECT-GUIDANCE.md`.
- **#118** AC was met in #138 (scripts + `docs/ops/post-deploy-verification.md` + `COOLIFY_DEPLOYMENT.md`); checklist/governance rows updated to done.

Fixes #117
Fixes #118

## Test plan

- [x] `bash -n bin/*.sh`
- [x] `bash bin/compose.sh config -q`
- [x] `./bin/smoke-local.sh` (compose lint, frontend build, OpenAPI JSON check)
- [ ] CI lint-and-unit (post-push)


Made with [Cursor](https://cursor.com)