### PR TITLE
[e2e] Frontend-only mode and stack docs (#152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: SEO sitemap route tests
         run: node --test tests/seo/sitemap.routes.test.js
 
+      - name: E2E runner config tests
+        run: node --test tests/e2e/run-e2e-config.test.js
+
       - name: Golden runner (integration gate skip)
         run: node tests/golden/runner.test.js
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,3 +1,6 @@
+# Playwright smoke — NOT a required PR gate (see docs/checklists/ua-testing.md L5).
+# Requires full stack: Postgres (ci_seed.sql), backend :3000, frontend :5173.
+# Local quick UI check without Docker: ./bin/run-e2e.sh --frontend-only
 name: E2E
 
 on:
@@ -57,14 +60,12 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      - name: Run smoke E2E
-        working-directory: tests/e2e
+      - name: Run smoke E2E (full stack)
         env:
           CI: 'true'
           FRONTEND_URL: http://127.0.0.1:5173
           API_URL: http://127.0.0.1:3000
-          SKIP_WEB_SERVER: '1'
-        run: npm test
+        run: ./bin/run-e2e.sh --with-stack
 
       - name: Upload Playwright report
         if: failure()

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,5 +1,11 @@
 # Progress Log
 
+## [2026-06-16] E2E frontend-only mode (#152)
+
+- `bin/run-e2e.sh`: `--frontend-only` / `--with-stack`, `--print-config`, `--help`.
+- Documented L5 modes and 10/16 baseline in `docs/checklists/ua-testing.md`.
+- CI: `tests/e2e/run-e2e-config.test.js` in `ci.yml`; `e2e.yml` uses `--with-stack`.
+
 ## [2026-06-16] UA3 live contract CI + UA10 debt register (#136, #119)
 
 - Wired `tests/contract/live-api-samples.test.js` into `ci-integration.yml` with `CONTRACT_FIXTURE=1`.

--- a/bin/bulletproof.sh
+++ b/bin/bulletproof.sh
@@ -23,7 +23,7 @@ fi
 API_URL="${API_URL:-${LOCAL_API_URL:-http://127.0.0.1:3000}}"
 if curl -sf "${API_URL}/health" >/dev/null 2>&1 && [[ -f bin/run-e2e.sh ]]; then
   echo "==> Playwright E2E (${FRONTEND_URL:-${LOCAL_FRONTEND_URL}})"
-  SKIP_WEB_SERVER=1 FRONTEND_URL="${FRONTEND_URL:-${LOCAL_FRONTEND_URL}}" bash bin/run-e2e.sh
+  FRONTEND_URL="${FRONTEND_URL:-${LOCAL_FRONTEND_URL}}" bash bin/run-e2e.sh --with-stack
 else
   echo "SKIP: Playwright E2E (API not running at ${API_URL} or bin/run-e2e.sh missing)"
 fi

--- a/bin/run-e2e.sh
+++ b/bin/run-e2e.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Playwright smoke against local frontend + API. Requires stack or dev server running.
+# Playwright smoke against local frontend + API.
+# Modes: --frontend-only (Playwright starts Vite) or --with-stack (stack already up).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -8,25 +9,101 @@ cd "${ROOT}"
 # shellcheck source=load-env.sh
 source "${ROOT}/bin/load-env.sh"
 
-cd tests/e2e
+E2E_MODE="with-stack"
 
-if [[ ! -d node_modules/@playwright/test ]]; then
-  echo "==> installing Playwright deps"
-  npm ci
-fi
+usage() {
+  cat <<'EOF'
+Usage: bin/run-e2e.sh [OPTIONS]
+
+Run Playwright E2E smoke tests.
+
+Modes:
+  --frontend-only   Playwright starts Vite (no Docker stack). ~10/16 tests pass
+                    without API (smoke UI + settings a11y); api.spec and proxy
+                    health need a running backend.
+  --with-stack      Expect frontend + API already running; default. Set via
+                    ./scripts/dev.sh or docker compose dev stack.
+
+Options:
+  --print-config    Print resolved URLs and mode, then exit (no tests)
+  -h, --help        Show this help
+
+Environment (optional overrides):
+  FRONTEND_URL      Frontend base URL (default: LOCAL_FRONTEND_URL or :5173)
+  API_URL           Backend base URL for api.spec.js (auto-detected when possible)
+  SKIP_WEB_SERVER   Legacy: 1 skips Vite webServer; unset lets Playwright start Vite.
+                    Mode flags take precedence over SKIP_WEB_SERVER.
+
+Examples:
+  ./bin/run-e2e.sh --frontend-only
+  ./scripts/dev.sh &  ./bin/run-e2e.sh --with-stack
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --frontend-only)
+      E2E_MODE="frontend-only"
+      shift
+      ;;
+    --with-stack)
+      E2E_MODE="with-stack"
+      shift
+      ;;
+    --print-config)
+      PRINT_CONFIG=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+apply_e2e_mode() {
+  case "${E2E_MODE}" in
+    frontend-only)
+      unset SKIP_WEB_SERVER
+      ;;
+    with-stack)
+      export SKIP_WEB_SERVER=1
+      ;;
+    *)
+      echo "internal error: unknown E2E_MODE=${E2E_MODE}" >&2
+      exit 2
+      ;;
+  esac
+}
+
+apply_e2e_mode
 
 export E2E_BROWSERS="${E2E_BROWSERS:-chromium}"
-echo "==> ensuring Playwright browser: ${E2E_BROWSERS}"
-npx playwright install "${E2E_BROWSERS}"
-
 export FRONTEND_URL="${FRONTEND_URL:-${LOCAL_FRONTEND_URL:-http://127.0.0.1:5173}}"
+
+if [[ "${PRINT_CONFIG:-}" == "1" ]]; then
+  printf 'E2E_MODE=%s\n' "${E2E_MODE}"
+  printf 'FRONTEND_URL=%s\n' "${FRONTEND_URL}"
+  printf 'API_URL=%s\n' "${API_URL:-${LOCAL_API_URL:-http://127.0.0.1:3000}}"
+  if [[ -n "${SKIP_WEB_SERVER:-}" ]]; then
+    printf 'SKIP_WEB_SERVER=%s\n' "${SKIP_WEB_SERVER}"
+  else
+    printf 'SKIP_WEB_SERVER=\n'
+  fi
+  exit 0
+fi
 
 resolve_api_url() {
   local candidate url
   for candidate in "${API_URL:-}" "${LOCAL_API_URL:-}" "http://127.0.0.1:3000" "http://127.0.0.1:3003"; do
     [[ -z "${candidate}" ]] && continue
     url="${candidate%/}"
-    if curl -sf "${url}/health" >/dev/null 2>&1; then
+    if curl -sf --connect-timeout 1 --max-time 2 "${url}/health" >/dev/null 2>&1; then
       echo "${url}"
       return 0
     fi
@@ -35,6 +112,16 @@ resolve_api_url() {
 }
 
 export API_URL="$(resolve_api_url)"
-export SKIP_WEB_SERVER="${SKIP_WEB_SERVER:-1}"
-echo "==> Playwright E2E at ${FRONTEND_URL} (API ${API_URL}, SKIP_WEB_SERVER=${SKIP_WEB_SERVER})"
+
+cd tests/e2e
+
+if [[ ! -d node_modules/@playwright/test ]]; then
+  echo "==> installing Playwright deps"
+  npm ci
+fi
+
+echo "==> ensuring Playwright browser: ${E2E_BROWSERS}"
+npx playwright install "${E2E_BROWSERS}"
+
+echo "==> Playwright E2E mode=${E2E_MODE} at ${FRONTEND_URL} (API ${API_URL}, SKIP_WEB_SERVER=${SKIP_WEB_SERVER:-})"
 npm test

--- a/docs/checklists/ua-testing.md
+++ b/docs/checklists/ua-testing.md
@@ -39,8 +39,26 @@ Use after UA2 (CI scaffold green). Aligns with [agentic-workflow-plan.md](../pla
 
 - [x] `tests/e2e/smoke.spec.js` (upcoming, today, settings, legacy API)
 - [x] `bin/run-e2e.sh` reads `FRONTEND_URL` from env
+- [x] `bin/run-e2e.sh` modes: `--frontend-only` vs `--with-stack` (#152)
 - [x] Playwright axe spot-checks (#120, #127)
 - [ ] Required PR gate (deferred until suite stable)
+
+### E2E run modes (#152)
+
+| Mode | Command | Prerequisites | Pass rate (baseline 2026-06-16) |
+| --- | --- | --- | --- |
+| **Frontend-only** | `./bin/run-e2e.sh --frontend-only` | Node 20; Playwright installs Chromium; no Docker | **10 / 16** — UI smoke + settings a11y |
+| **Full stack** | `./scripts/dev.sh` then `./bin/run-e2e.sh --with-stack` | Compose db + backend + frontend (or dev script equivalent) | **16 / 16** when API + proxy healthy |
+
+`--frontend-only` leaves `SKIP_WEB_SERVER` unset so Playwright starts Vite (`tests/e2e/playwright.config.js`). `--with-stack` sets `SKIP_WEB_SERVER=1` and expects `FRONTEND_URL` / `API_URL` (or `LOCAL_*`) to point at a running stack.
+
+**Tests that require a live API** (fail in frontend-only):
+
+- `tests/e2e/api.spec.js` (4) — direct backend contract calls
+- `smoke.spec.js` → `API health via frontend proxy` — Vite/nginx proxy to backend
+- `accessibility.spec.js` → `today has no critical a11y violations` — needs price table data from API
+
+**CI E2E workflow** (`.github/workflows/e2e.yml`): scheduled / `workflow_dispatch` only; starts full Docker dev stack (db + `ci_seed.sql` + backend + frontend), then runs `./bin/run-e2e.sh --with-stack` equivalent (`SKIP_WEB_SERVER=1`). Not a required PR gate until suite is stable.
 
 ## Contract PR gate (UA3)
 
@@ -60,11 +78,14 @@ npm test --prefix backend
 npm test --prefix electricity-prices-build
 INTEGRATION_TESTS=1 API_URL=http://127.0.0.1:3001 node tests/golden/runner.test.js
 CONTRACT_LIVE=1 CONTRACT_FIXTURE=1 API_URL=http://127.0.0.1:3001 node --test tests/contract/live-api-samples.test.js
-./bin/run-e2e.sh
+./bin/run-e2e.sh --frontend-only
+./bin/run-e2e.sh --with-stack   # after ./scripts/dev.sh or compose stack
+node --test tests/e2e/run-e2e-config.test.js
 ```
 
 ## Exit criteria (UA3 + UA6)
 
 - QA agent runs golden + contract without manual curl
-- `./bin/run-e2e.sh` passes against local compose stack
+- `./bin/run-e2e.sh --with-stack` passes against local compose stack
+- `./bin/run-e2e.sh --frontend-only` passes UI smoke without Docker (10/16 baseline)
 - CI documents which layers run on PR vs integration vs nightly

--- a/tests/e2e/run-e2e-config.test.js
+++ b/tests/e2e/run-e2e-config.test.js
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const RUN_E2E = path.join(ROOT, 'bin', 'run-e2e.sh');
+
+function printConfig(args = []) {
+  return spawnSync('bash', [RUN_E2E, '--print-config', ...args], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FRONTEND_URL: 'http://127.0.0.1:5999',
+      API_URL: 'http://127.0.0.1:3999',
+      SKIP_WEB_SERVER: 'legacy-should-be-overridden',
+    },
+  });
+}
+
+function parseConfig(stdout) {
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const idx = line.indexOf('=');
+        return [line.slice(0, idx), line.slice(idx + 1)];
+      }),
+  );
+}
+
+test('run-e2e.sh passes bash -n', () => {
+  const result = spawnSync('bash', ['-n', RUN_E2E], { cwd: ROOT });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('--frontend-only clears SKIP_WEB_SERVER', () => {
+  const result = printConfig(['--frontend-only']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const cfg = parseConfig(result.stdout);
+  assert.equal(cfg.E2E_MODE, 'frontend-only');
+  assert.equal(cfg.SKIP_WEB_SERVER, '');
+  assert.equal(cfg.FRONTEND_URL, 'http://127.0.0.1:5999');
+});
+
+test('--with-stack sets SKIP_WEB_SERVER=1', () => {
+  const result = printConfig(['--with-stack']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const cfg = parseConfig(result.stdout);
+  assert.equal(cfg.E2E_MODE, 'with-stack');
+  assert.equal(cfg.SKIP_WEB_SERVER, '1');
+});
+
+test('default mode is with-stack', () => {
+  const result = printConfig();
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const cfg = parseConfig(result.stdout);
+  assert.equal(cfg.E2E_MODE, 'with-stack');
+  assert.equal(cfg.SKIP_WEB_SERVER, '1');
+});
+
+test('--help exits 0', () => {
+  const result = spawnSync('bash', [RUN_E2E, '--help'], { cwd: ROOT, encoding: 'utf8' });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--frontend-only/);
+});


### PR DESCRIPTION
## Summary

- Add `--frontend-only` and `--with-stack` flags to `bin/run-e2e.sh` (default: with-stack) so UI smoke can run without Docker when Playwright starts Vite.
- Document L5 E2E modes, 10/16 frontend-only baseline, and API-dependent specs in `docs/checklists/ua-testing.md`.
- Wire `e2e.yml` through `run-e2e.sh --with-stack`; add `tests/e2e/run-e2e-config.test.js` to PR CI.

## Test plan

- [x] `bash -n bin/run-e2e.sh bin/bulletproof.sh`
- [x] `node --test tests/e2e/run-e2e-config.test.js`
- [x] `./bin/run-e2e.sh --frontend-only` → 10 passed, 6 failed (expected without API)

## Notes

- PR #153 (UA4 golden) is open with green `integration-golden`; not merged yet at time of this PR.

Fixes #152

Made with [Cursor](https://cursor.com)