### PR TITLE
[today] Fix past-date fetch and empty-state message

### DIFF
--- a/electricity-prices-build/src/components/PriceTable.vue
+++ b/electricity-prices-build/src/components/PriceTable.vue
@@ -5,6 +5,7 @@ import { formatPriceHours, isCurrentHour } from '../services/timeService';
 import { calculatePrice, getTimePeriod } from '../services/priceCalculationService';
 import { getPriceClass } from '../utils/priceColor';
 import { getColorThresholdSettings } from '../services/alertSettingsService';
+import { isHistoricalDate } from '../utils/releaseWindow';
 
 const props = defineProps({
   priceData: {
@@ -16,10 +17,22 @@ const props = defineProps({
     type: Array,
     required: false,
     default: null // Will use priceData if not provided
-  }
+  },
+  selectedDate: {
+    type: String,
+    required: false,
+    default: null,
+  },
 })
 
 const hasEnoughData = computed(() => props.priceData && props.priceData.length >= 3)
+
+const emptyStateMessageKey = computed(() => {
+  if (props.selectedDate && isHistoricalDate(props.selectedDate)) {
+    return 'table.noDataHistorical';
+  }
+  return 'table.noData';
+});
 
 const intervalSeconds = computed(() => {
   if (props.priceData && props.priceData.length >= 2) {
@@ -209,7 +222,7 @@ const groupedByHour = computed(() => {
 
 <template>
   <div v-if="!hasEnoughData" class="alert alert-warning" role="alert">
-    <span v-html="$t('table.noData').replace('\n', '<br>')"></span>
+    <span v-html="$t(emptyStateMessageKey).replace('\n', '<br>')"></span>
   </div>
   <div v-else class="table-responsive">
     <table class="table table-hover align-middle">

--- a/electricity-prices-build/src/i18n.js
+++ b/electricity-prices-build/src/i18n.js
@@ -95,6 +95,7 @@ const messages = {
     },
     table: {
       noData: 'Price data is not yet available for selected date.\nData is typically available after 15:00 local time (13:00 UTC).',
+      noDataHistorical: 'No price data is available for this date in our database.',
       intervalHeader: 'Interval',
       priceHeader: 'Price ct/kWh',
       hourHeader: 'Prices in cents',
@@ -239,6 +240,7 @@ const messages = {
     },
     table: {
       noData: 'Šiai datai kainų duomenys dar nepasiekiami.\nDuomenys įprastai pasiekiami po 15:00 vietos laiku (13:00 UTC).',
+      noDataHistorical: 'Šiai datai kainų duomenų bazėje nėra.',
       intervalHeader: 'Intervalas',
       priceHeader: 'Kaina ct/kWh',
       hourHeader: 'Kainos centais',

--- a/electricity-prices-build/src/services/priceCacheService.js
+++ b/electricity-prices-build/src/services/priceCacheService.js
@@ -68,8 +68,8 @@ export function getCachedPrices(startDate, endDate, country = 'lt') {
   
   if (countryData.length === 0) return null;
   
-  const startTs = moment(startDate).startOf('day').unix();
-  const endTs = moment(endDate).endOf('day').unix();
+  const startTs = moment.tz(startDate, DISPLAY_TIMEZONE).startOf('day').unix();
+  const endTs = moment.tz(endDate, DISPLAY_TIMEZONE).endOf('day').unix();
   
   const filtered = countryData.filter(price => {
     return price.timestamp >= startTs && price.timestamp <= endTs;

--- a/electricity-prices-build/src/services/priceService.js
+++ b/electricity-prices-build/src/services/priceService.js
@@ -18,6 +18,8 @@ import {
   getMsUntilNextWindowStart,
   isHistoricalDate,
   shouldFetchFutureData,
+  toDisplayDayMoment,
+  formatDisplayDateString,
   RELEASE_PHASE,
 } from '../utils/releaseWindow';
 import { isDaySynced } from '../utils/deviceSyncState';
@@ -87,16 +89,16 @@ function canFetchFromNetwork(date, { force = false } = {}) {
 export async function fetchPrices(date, country = 'lt', options = {}) {
   getPriceSettings();
 
-  const formattedDate = moment(date).tz(DISPLAY_TIMEZONE).format('YYYY-MM-DD');
-  const startDate = moment(date).tz(DISPLAY_TIMEZONE).startOf('day');
-  const endDate = moment(date).tz(DISPLAY_TIMEZONE).endOf('day');
+  const dayMoment = toDisplayDayMoment(date);
+  const formattedDate = formatDisplayDateString(date);
+  const startDate = dayMoment.clone();
+  const endDate = dayMoment.clone().endOf('day');
   const cached = getCachedPrices(startDate.toDate(), endDate.toDate(), country);
 
   if (cached && cached.length > 0) {
     const validation = validateDayCompleteness(formattedDate, country);
-    const isHistorical = isHistoricalDate(date);
 
-    if (isHistorical || validation.isComplete || !canFetchFromNetwork(date, options)) {
+    if (validation.isComplete || !canFetchFromNetwork(date, options)) {
       return buildCachedResponse(cached, country, { date: formattedDate });
     }
   } else if (!canFetchFromNetwork(date, options)) {

--- a/electricity-prices-build/src/utils/releaseWindow.js
+++ b/electricity-prices-build/src/utils/releaseWindow.js
@@ -139,10 +139,28 @@ export function shouldFetchFutureData(date, now = moment()) {
 }
 
 /**
+ * Parse any date input to the start of that calendar day in Vilnius.
+ * @param {Date|string|import('moment').Moment} date
+ */
+export function toDisplayDayMoment(date) {
+  if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return moment.tz(date, DISPLAY_TIMEZONE).startOf('day');
+  }
+  return moment(date).tz(DISPLAY_TIMEZONE).startOf('day');
+}
+
+/**
+ * @param {Date|string|import('moment').Moment} date
+ */
+export function formatDisplayDateString(date) {
+  return toDisplayDayMoment(date).format('YYYY-MM-DD');
+}
+
+/**
  * @param {Date|string|import('moment').Moment} date
  * @param {import('moment').Moment} [now]
  */
 export function isHistoricalDate(date, now = moment()) {
   const nowVilnius = now.clone().tz(DISPLAY_TIMEZONE);
-  return moment(date).tz(DISPLAY_TIMEZONE).isBefore(nowVilnius, 'day');
+  return toDisplayDayMoment(date).isBefore(nowVilnius, 'day');
 }

--- a/electricity-prices-build/src/views/TodayView.vue
+++ b/electricity-prices-build/src/views/TodayView.vue
@@ -349,7 +349,7 @@ function setTomorrow() {
 
       </div>
 
-      <PriceTable v-else :priceData="priceData" />
+      <PriceTable v-else :priceData="priceData" :selectedDate="selectedDate" />
 
     </div>
 

--- a/electricity-prices-build/tests/priceService.test.js
+++ b/electricity-prices-build/tests/priceService.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import moment from 'moment-timezone';
+import axios from 'axios';
+import { DISPLAY_TIMEZONE } from '../src/utils/releaseWindow.js';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../src/services/logService.js', () => ({
+  logApiCall: vi.fn(),
+}));
+
+const NOW = moment.tz('2026-06-16 05:00', DISPLAY_TIMEZONE);
+
+function buildHourlyDay(dateStr, count = 24) {
+  const base = moment.tz(dateStr, DISPLAY_TIMEZONE).startOf('day');
+  return Array.from({ length: count }, (_, index) => ({
+    timestamp: base.clone().add(index, 'hours').unix(),
+    price: 40 + index,
+  }));
+}
+
+function seedCache(ltPrices) {
+  const payload = {
+    version: 1,
+    data: { lt: ltPrices },
+    lastUpdated: Date.now(),
+  };
+  localStorage.setItem('priceDataCache', JSON.stringify(payload));
+}
+
+describe('fetchPrices historical dates', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW.toDate());
+    vi.clearAllMocks();
+    vi.stubGlobal('import.meta', { env: { VITE_API_BASE_URL: '/api/v1' } });
+    vi.stubGlobal('localStorage', {
+      store: {},
+      getItem(key) {
+        return this.store[key] ?? null;
+      },
+      setItem(key, value) {
+        this.store[key] = value;
+      },
+      removeItem(key) {
+        delete this.store[key];
+      },
+    });
+    localStorage.removeItem('priceDataCache');
+    axios.get.mockResolvedValue({
+      data: {
+        success: true,
+        data: { lt: buildHourlyDay('2026-06-14') },
+        meta: { country: 'lt', count: 24 },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches from API when historical day has no cache', async () => {
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    const date = moment.tz('2026-06-14', DISPLAY_TIMEZONE).startOf('day').toDate();
+
+    const result = await fetchPrices(date, 'lt');
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(axios.get.mock.calls[0][0]).toContain('nps/prices?date=2026-06-14&country=lt');
+    expect(result.data.lt).toHaveLength(24);
+  });
+
+  it('fetches from API when historical day cache is incomplete', async () => {
+    seedCache(buildHourlyDay('2026-06-14', 2));
+
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    const date = moment.tz('2026-06-14', DISPLAY_TIMEZONE).startOf('day').toDate();
+
+    await fetchPrices(date, 'lt');
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(axios.get.mock.calls[0][0]).toContain('nps/prices?date=2026-06-14&country=lt');
+  });
+
+  it('uses complete historical cache without network', async () => {
+    seedCache(buildHourlyDay('2026-06-14'));
+
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    const date = moment.tz('2026-06-14', DISPLAY_TIMEZONE).startOf('day').toDate();
+
+    const result = await fetchPrices(date, 'lt');
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(result.meta.cached).toBe(true);
+    expect(result.data.lt).toHaveLength(24);
+  });
+
+  it('skips network for tomorrow before release window when cache is empty', async () => {
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    const date = moment.tz('2026-06-17', DISPLAY_TIMEZONE).startOf('day').toDate();
+
+    const result = await fetchPrices(date, 'lt');
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(result.meta.skippedNetwork).toBe(true);
+    expect(result.data.lt).toEqual([]);
+  });
+});

--- a/electricity-prices-build/tests/priceTable.test.js
+++ b/electricity-prices-build/tests/priceTable.test.js
@@ -40,15 +40,24 @@ describe('PriceTable empty state', () => {
     });
   });
 
-  it('shows warning only when fewer than three price rows', () => {
+  it('shows historical empty message for past selected dates', () => {
+    const wrapper = mount(PriceTable, {
+      props: { priceData: [], selectedDate: '2026-06-14' },
+      global: { mocks: { $t: (key) => key } },
+    });
+
+    expect(wrapper.find('.alert-warning').exists()).toBe(true);
+    expect(wrapper.text()).toContain('table.noDataHistorical');
+  });
+
+  it('shows release-window message when no selected date is provided', () => {
     const wrapper = mount(PriceTable, {
       props: { priceData: [] },
       global: { mocks: { $t: (key) => key } },
     });
 
-    expect(wrapper.find('.alert-warning').exists()).toBe(true);
-    expect(wrapper.find('table.table').exists()).toBe(false);
-    expect(wrapper.text()).not.toContain('0.000');
+    expect(wrapper.text()).toContain('table.noData');
+    expect(wrapper.text()).not.toContain('table.noDataHistorical');
   });
 
   it('shows average badge when enough hourly rows exist', () => {

--- a/electricity-prices-build/tests/releaseWindow.test.js
+++ b/electricity-prices-build/tests/releaseWindow.test.js
@@ -3,7 +3,9 @@ import moment from 'moment-timezone';
 import {
   shouldFetchFutureData,
   isCurrentDisplayDay,
+  isHistoricalDate,
   getTargetReleaseDay,
+  toDisplayDayMoment,
   DISPLAY_TIMEZONE,
 } from '../src/utils/releaseWindow.js';
 
@@ -30,5 +32,11 @@ describe('shouldFetchFutureData', () => {
     const dayAfterTomorrow = now.clone().add(2, 'day').startOf('day').toDate();
 
     expect(shouldFetchFutureData(dayAfterTomorrow, now)).toBe(false);
+  });
+
+  it('parses YYYY-MM-DD strings in Vilnius timezone', () => {
+    const day = toDisplayDayMoment('2026-06-14');
+    expect(day.format('YYYY-MM-DD HH:mm:ss Z')).toBe('2026-06-14 00:00:00 +03:00');
+    expect(isHistoricalDate('2026-06-14', moment.tz('2026-06-16', DISPLAY_TIMEZONE))).toBe(true);
   });
 });

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -83,6 +83,62 @@ test.describe('frontend smoke', () => {
     }
   });
 
+  test('today past date loads prices from API when cache is empty', async ({ page }) => {
+    const frozenNow = new Date('2026-06-16T05:00:00+03:00');
+    const slot = (date, hour) =>
+      Math.floor(new Date(`${date}T${hour}:00:00+03:00`).getTime() / 1000);
+    const pastDate = '2026-06-14';
+    const apiPrices = ['00', '01', '02'].map((hour, index) => ({
+      timestamp: slot(pastDate, hour),
+      price: 40 + index,
+    }));
+
+    await page.clock.install({ time: frozenNow });
+    await page.route('**/api/v1/nps/prices?date=2026-06-14&country=lt', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { lt: apiPrices },
+          meta: { country: 'lt', count: apiPrices.length, timezone: 'Europe/Vilnius' },
+        }),
+      });
+    });
+
+    await page.goto(`/today?lang=lt&date=${pastDate}`);
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+
+    const table = page.locator('table.table');
+    await expect(table).toBeVisible();
+    await expect(table.locator('tbody tr')).toHaveCount(3);
+    await expect(page.getByText('Šiai datai kainų duomenys dar nepasiekiami.')).toHaveCount(0);
+    await expect(page.getByText('Šiai datai kainų duomenų bazėje nėra.')).toHaveCount(0);
+  });
+
+  test('today past date shows historical empty message when API has no data', async ({ page }) => {
+    const frozenNow = new Date('2026-06-16T05:00:00+03:00');
+    const pastDate = '2026-06-14';
+
+    await page.clock.install({ time: frozenNow });
+    await page.route('**/api/v1/nps/prices?date=2026-06-14&country=lt', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { lt: [] },
+          meta: { country: 'lt', count: 0, timezone: 'Europe/Vilnius' },
+        }),
+      });
+    });
+
+    await page.goto(`/today?lang=lt&date=${pastDate}`);
+    await expect(page.getByText(LOADING_TEXT)).toBeHidden({ timeout: 20_000 });
+    await expect(page.getByText('Šiai datai kainų duomenų bazėje nėra.')).toBeVisible();
+    await expect(page.getByText('Šiai datai kainų duomenys dar nepasiekiami.')).toHaveCount(0);
+  });
+
   test('today tomorrow button keeps date visible in empty-data window', async ({ page }) => {
     await page.goto('/today?lang=lt');
     const todayPage = page.locator('.today-page');


### PR DESCRIPTION
## Summary
- **Root cause:** `fetchPrices` returned incomplete localStorage cache for historical days without hitting the API (`isHistorical` short-circuited network). `getCachedPrices` also used browser-local midnight instead of Vilnius bounds (21h skew on UTC browsers), causing wrong cache hits/misses.
- Historical days now fetch from API when cache is empty or incomplete; complete cache still served offline.
- `PriceTable` shows a dedicated historical empty message for past dates instead of the Nord Pool release-window copy.

Fixes #155

## Test plan
- [x] `npm test --prefix electricity-prices-build` (41 tests, incl. new `priceService.test.js` + `PriceTable`/`releaseWindow` cases)
- [x] E2E scenarios added in `tests/e2e/smoke.spec.js` for past-date API load + historical empty message
- [ ] CI lint-and-unit + integration


Made with [Cursor](https://cursor.com)