### PR TITLE
[frontend] Today view API-down and past-date messaging

### DIFF
--- a/electricity-prices-build/src/i18n.js
+++ b/electricity-prices-build/src/i18n.js
@@ -13,6 +13,9 @@ const messages = {
       today: 'Today',
       tomorrow: 'Tomorrow'
     },
+    today: {
+      apiUnavailable: 'Cannot load prices — the API is unavailable. Start the backend stack (docker compose up) and try again.',
+    },
     display: {
       invalidTitle: 'Invalid display link',
       invalidBody: 'This shared layout link is missing or could not be decoded. Ask the sender for a new link.',
@@ -157,6 +160,9 @@ const messages = {
       title: 'Elektros kainos',
       today: 'Šiandien',
       tomorrow: 'Rytoj'
+    },
+    today: {
+      apiUnavailable: 'Nepavyko įkelti kainų — API nepasiekiamas. Paleiskite backend (docker compose up) ir bandykite dar kartą.',
     },
     display: {
       invalidTitle: 'Netinkama rodinio nuoroda',

--- a/electricity-prices-build/src/services/priceService.js
+++ b/electricity-prices-build/src/services/priceService.js
@@ -124,11 +124,14 @@ export async function fetchPrices(date, country = 'lt', options = {}) {
   } catch (error) {
     console.error('Error fetching prices:', error);
     if (cached && cached.length > 0) {
-      console.log('[Cache] Using cached data as fallback for date', formattedDate);
-      return buildCachedResponse(cached, country, {
-        date: formattedDate,
-        offline: true,
-      });
+      const validation = validateDayCompleteness(formattedDate, country);
+      if (validation.isComplete) {
+        console.log('[Cache] Using complete cached data as fallback for date', formattedDate);
+        return buildCachedResponse(cached, country, {
+          date: formattedDate,
+          offline: true,
+        });
+      }
     }
     throw error;
   }

--- a/electricity-prices-build/src/views/TodayView.vue
+++ b/electricity-prices-build/src/views/TodayView.vue
@@ -73,6 +73,7 @@ const priceData = ref([]);
 const isLoading = ref(true);
 
 const error = ref(null);
+const errorKind = ref(null);
 
 
 
@@ -159,11 +160,13 @@ async function reloadPrices() {
     try {
       isLoading.value = true;
       error.value = null;
+      errorKind.value = null;
       const data = await fetchPrices(selectedDateAsDate());
       priceData.value = data.data?.lt || [];
       await nextTick();
       logAllPriceBreakdowns();
     } catch (err) {
+      errorKind.value = err?.response ? 'load' : 'network';
       error.value = err?.message || 'Failed to load prices';
       priceData.value = [];
     } finally {
@@ -345,7 +348,7 @@ function setTomorrow() {
 
       <div v-else-if="error" class="alert alert-danger">
 
-        {{ $t('upcoming.error') }}
+        {{ $t(errorKind === 'network' ? 'today.apiUnavailable' : 'upcoming.error') }}
 
       </div>
 

--- a/electricity-prices-build/tests/priceService.test.js
+++ b/electricity-prices-build/tests/priceService.test.js
@@ -110,4 +110,14 @@ describe('fetchPrices historical dates', () => {
     expect(result.meta.skippedNetwork).toBe(true);
     expect(result.data.lt).toEqual([]);
   });
+
+  it('throws on network error when historical cache is incomplete', async () => {
+    seedCache(buildHourlyDay('2026-06-14', 2));
+    axios.get.mockRejectedValueOnce(new Error('Network Error'));
+
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    const date = moment.tz('2026-06-14', DISPLAY_TIMEZONE).startOf('day').toDate();
+
+    await expect(fetchPrices(date, 'lt')).rejects.toThrow('Network Error');
+  });
 });

--- a/electricity-prices-build/tests/views.smoke.test.js
+++ b/electricity-prices-build/tests/views.smoke.test.js
@@ -129,6 +129,31 @@ describe('TodayView smoke', () => {
     expect(wrapper.find('.date-picker-stub').element.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(wrapper.find('[data-empty="true"]').exists()).toBe(true);
   });
+
+  it('shows API unavailable message when fetch fails with network error', async () => {
+    const { fetchPrices } = await import('../src/services/priceService.js');
+    fetchPrices.mockRejectedValueOnce(Object.assign(new Error('Network Error'), { response: undefined }));
+
+    const TodayView = (await import('../src/views/TodayView.vue')).default;
+    const wrapper = mount(TodayView, {
+      global: {
+        stubs: {
+          VueDatePicker: {
+            template: '<input class="date-picker-stub" :value="modelValue" readonly />',
+            props: ['modelValue'],
+          },
+          PriceTable: true,
+        },
+        mocks: { $t: (key) => key },
+      },
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(wrapper.find('.alert-danger').exists()).toBe(true);
+    expect(wrapper.text()).toContain('today.apiUnavailable');
+    expect(wrapper.find('.alert-warning').exists()).toBe(false);
+  });
 });
 
 describe('UpcomingPricesView smoke', () => {


### PR DESCRIPTION
## Summary
- Root cause: API on `:3000` is down (Docker Desktop engine unresponsive; `curl` returns connection failure). With backend unavailable, `fetchPrices` could fall back to incomplete cache and `PriceTable` showed the tomorrow/15:00 empty banner even for past dates like 2026-06-14.
- Today view now shows a red **API unavailable** banner on network failures (not the orange release-window message).
- Network errors no longer mask behind incomplete cache; only complete cached days are used offline.
- Past-date empty state (`noDataHistorical`) was already on `main` from prior work; this PR completes API-down handling.

## Test plan
- [x] `npm test --prefix electricity-prices-build` (43 tests)
- [x] `npm run build --prefix electricity-prices-build`
- [x] `curl http://localhost:3000/api/v1/health` → connection failed (Docker timeout)
- [ ] CI lint-and-unit

Fixes #157

Made with [Cursor](https://cursor.com)